### PR TITLE
Map storage support and assorted v2 improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,11 @@ services:
       - "8080:8080"
     environment:
       - STATS_DIR=/app/stats
+      - MAPS_DIR=/app/maps
     volumes:
       - stats_data:/app/stats
+      - maps_data:/app/maps
 
 volumes:
   stats_data:
+  maps_data:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,9 +15,155 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/add_map": {
+            "post": {
+                "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Upload a map asset (.map or .tga preview)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal); identifies the map",
+                        "name": "X-Map-CRC",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Original map path/name from the game (e.g. \\",
+                        "name": "X-Map-Name",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Asset kind: \\",
+                        "name": "X-Map-File",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Game seed for telemetry correlation",
+                        "name": "X-Game-Seed",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/get_map": {
+            "get": {
+                "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
+                "produces": [
+                    "application/zip"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Download the map and preview as a zip",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Zip archive (application/zip)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/map_exists": {
+            "get": {
+                "description": "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Check whether a map exists on the server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal, as emitted by MapMetaData::m_CRC)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "\\\"true\\\" or \\\"false\\",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/replay": {
             "post": {
-                "description": "Upload a .rep replay file and receive parsed replay data. Returns enhanced v2 stats if a matching stats file exists, otherwise returns the basic parsed replay.",
+                "description": "Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.",
                 "consumes": [
                     "multipart/form-data"
                 ],

--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -864,9 +864,202 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/add_map": {
+      "post": {
+        "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+        "parameters": [
+          {
+            "description": "Map CRC (decimal); identifies the map",
+            "in": "header",
+            "name": "X-Map-CRC",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Original map path/name from the game (e.g. \\",
+            "in": "header",
+            "name": "X-Map-Name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Asset kind: \\",
+            "in": "header",
+            "name": "X-Map-File",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Game seed for telemetry correlation",
+            "in": "header",
+            "name": "X-Game-Seed",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Upload a map asset (.map or .tga preview)",
+        "tags": [
+          "maps"
+        ]
+      }
+    },
+    "/get_map": {
+      "get": {
+        "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
+        "parameters": [
+          {
+            "description": "Map CRC (decimal)",
+            "in": "query",
+            "name": "crc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "file"
+                }
+              }
+            },
+            "description": "Zip archive (application/zip)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Download the map and preview as a zip",
+        "tags": [
+          "maps"
+        ]
+      }
+    },
+    "/map_exists": {
+      "get": {
+        "description": "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.",
+        "parameters": [
+          {
+            "description": "Map CRC (decimal, as emitted by MapMetaData::m_CRC)",
+            "in": "query",
+            "name": "crc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "\\\"true\\\" or \\\"false\\"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          }
+        },
+        "summary": "Check whether a map exists on the server",
+        "tags": [
+          "maps"
+        ]
+      }
+    },
     "/replay": {
       "post": {
-        "description": "Upload a .rep replay file and receive parsed replay data. Returns enhanced v2 stats if a matching stats file exists, otherwise returns the basic parsed replay.",
+        "description": "Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.",
         "requestBody": {
           "content": {
             "multipart/form-data": {

--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -585,9 +585,129 @@ info:
   version: 2.0
 openapi: 3.0.3
 paths:
+  /add_map:
+    post:
+      description: Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.
+      parameters:
+        - description: Map CRC (decimal); identifies the map
+          in: header
+          name: X-Map-CRC
+          required: true
+          schema:
+            type: string
+        - description: Original map path/name from the game (e.g. \
+          in: header
+          name: X-Map-Name
+          schema:
+            type: string
+        - description: "Asset kind: \\"
+          in: header
+          name: X-Map-File
+          required: true
+          schema:
+            type: string
+        - description: Game seed for telemetry correlation
+          in: header
+          name: X-Game-Seed
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              format: binary
+              type: string
+        required: true
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+          description: OK
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Internal Server Error
+      summary: Upload a map asset (.map or .tga preview)
+      tags:
+        - maps
+  /get_map:
+    get:
+      description: "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory."
+      parameters:
+        - description: Map CRC (decimal)
+          in: query
+          name: crc
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: file
+          description: Zip archive (application/zip)
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Not Found
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Internal Server Error
+      summary: Download the map and preview as a zip
+      tags:
+        - maps
+  /map_exists:
+    get:
+      description: "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map."
+      parameters:
+        - description: "Map CRC (decimal, as emitted by MapMetaData::m_CRC)"
+          in: query
+          name: crc
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: string
+          description: "\\\"true\\\" or \\\"false\\"
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+      summary: Check whether a map exists on the server
+      tags:
+        - maps
   /replay:
     post:
-      description: "Upload a .rep replay file and receive parsed replay data. Returns enhanced v2 stats if a matching stats file exists, otherwise returns the basic parsed replay."
+      description: Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.
       requestBody:
         content:
           multipart/form-data:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,9 +9,155 @@
     "host": "localhost:8080",
     "basePath": "/",
     "paths": {
+        "/add_map": {
+            "post": {
+                "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Upload a map asset (.map or .tga preview)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal); identifies the map",
+                        "name": "X-Map-CRC",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Original map path/name from the game (e.g. \\",
+                        "name": "X-Map-Name",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Asset kind: \\",
+                        "name": "X-Map-File",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Game seed for telemetry correlation",
+                        "name": "X-Game-Seed",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/get_map": {
+            "get": {
+                "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
+                "produces": [
+                    "application/zip"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Download the map and preview as a zip",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Zip archive (application/zip)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/map_exists": {
+            "get": {
+                "description": "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Check whether a map exists on the server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal, as emitted by MapMetaData::m_CRC)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "\\\"true\\\" or \\\"false\\",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/replay": {
             "post": {
-                "description": "Upload a .rep replay file and receive parsed replay data. Returns enhanced v2 stats if a matching stats file exists, otherwise returns the basic parsed replay.",
+                "description": "Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.",
                 "consumes": [
                     "multipart/form-data"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -582,13 +582,115 @@ info:
   title: CNC Stats API
   version: "2.0"
 paths:
+  /add_map:
+    post:
+      consumes:
+      - application/octet-stream
+      description: Stores one of the two assets that make up a map (the .map file
+        or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently.
+        Two calls (one per asset kind) are expected per map.
+      parameters:
+      - description: Map CRC (decimal); identifies the map
+        in: header
+        name: X-Map-CRC
+        required: true
+        type: string
+      - description: Original map path/name from the game (e.g. \
+        in: header
+        name: X-Map-Name
+        type: string
+      - description: 'Asset kind: \'
+        in: header
+        name: X-Map-File
+        required: true
+        type: string
+      - description: Game seed for telemetry correlation
+        in: header
+        name: X-Game-Seed
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Upload a map asset (.map or .tga preview)
+      tags:
+      - maps
+  /get_map:
+    get:
+      description: Returns a zip archive whose entries are the .map file and (if available)
+        the .tga preview, named after the original map basename. Suitable for direct
+        extraction into a Generals Maps/ subdirectory.
+      parameters:
+      - description: Map CRC (decimal)
+        in: query
+        name: crc
+        required: true
+        type: string
+      produces:
+      - application/zip
+      responses:
+        "200":
+          description: Zip archive (application/zip)
+          schema:
+            type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Download the map and preview as a zip
+      tags:
+      - maps
+  /map_exists:
+    get:
+      description: Returns plain-text "true" if a .map file is already stored under
+        MAPS_DIR for the given crc, "false" otherwise. Used by the Generals client
+        right after a game ends to decide whether to upload its played map.
+      parameters:
+      - description: Map CRC (decimal, as emitted by MapMetaData::m_CRC)
+        in: query
+        name: crc
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: \"true\" or \"false\
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Check whether a map exists on the server
+      tags:
+      - maps
   /replay:
     post:
       consumes:
       - multipart/form-data
-      description: Upload a .rep replay file and receive parsed replay data. Returns
-        enhanced v2 stats if a matching stats file exists, otherwise returns the basic
-        parsed replay.
+      description: Upload a .rep replay file and receive parsed replay data in v2
+        format. Stats fields are populated when a matching stats file exists.
       parameters:
       - description: Replay file to parse
         in: formData

--- a/inizh/Data/INI/ZuluColors.ini
+++ b/inizh/Data/INI/ZuluColors.ini
@@ -1,0 +1,38 @@
+;//////////////////////////////////////////////////////////////////////////////
+; FILE: ZuluColors.ini /////////////////////////////////////////////////////////
+; Additional MultiplayerColor entries shipped by the Zulu mod. Loaded after
+; the base Color.ini so these blocks are appended to the color list without
+; touching the originals.
+;//////////////////////////////////////////////////////////////////////////////
+
+MultiplayerColor Maroon
+  TooltipName = Color:Maroon
+  RGBColor = R:128 G:0 B:0
+  RGBNightColor = R:100 G:0 B:0
+End
+
+MultiplayerColor Lime
+  TooltipName = Color:Lime
+  RGBColor = R:170 G:255 B:0
+  RGBNightColor = R:133 G:200 B:0
+End
+
+MultiplayerColor Brown
+  TooltipName = Color:Brown
+  RGBColor = R:139 G:69 B:19
+  RGBNightColor = R:108 G:54 B:15
+End
+
+MultiplayerColor Silver
+  TooltipName = Color:Silver
+  RGBColor = R:192 G:192 B:192
+  RGBNightColor = R:150 G:150 B:150
+End
+
+MultiplayerColor Black
+  TooltipName = Color:Black
+  ; Engine treats RGB(0,0,0) as "no recolor" sentinel (W3DAssetManager.cpp),
+  ; so use near-black to trigger team color remapping.
+  RGBColor = R:1 G:1 B:1
+  RGBNightColor = R:1 G:1 B:1
+End

--- a/inizh/Data/INI/ZuluColors.ini
+++ b/inizh/Data/INI/ZuluColors.ini
@@ -5,31 +5,31 @@
 ; touching the originals.
 ;//////////////////////////////////////////////////////////////////////////////
 
-MultiplayerColor Maroon
+MultiplayerColor ColorMaroon
   TooltipName = Color:Maroon
   RGBColor = R:128 G:0 B:0
   RGBNightColor = R:100 G:0 B:0
 End
 
-MultiplayerColor Lime
+MultiplayerColor ColorLime
   TooltipName = Color:Lime
   RGBColor = R:170 G:255 B:0
   RGBNightColor = R:133 G:200 B:0
 End
 
-MultiplayerColor Brown
+MultiplayerColor ColorBrown
   TooltipName = Color:Brown
   RGBColor = R:139 G:69 B:19
   RGBNightColor = R:108 G:54 B:15
 End
 
-MultiplayerColor Silver
-  TooltipName = Color:Silver
-  RGBColor = R:192 G:192 B:192
-  RGBNightColor = R:150 G:150 B:150
+MultiplayerColor ColorMetallicGrey
+  TooltipName = Color:Metallic Grey
+  RGBColor = R:112 G:128 B:144
+  RGBNightColor = R:112 G:128 B:144
 End
 
-MultiplayerColor Black
+MultiplayerColor ColorBlack
   TooltipName = Color:Black
   ; Engine treats RGB(0,0,0) as "no recolor" sentinel (W3DAssetManager.cpp),
   ; so use near-black to trigger team color remapping.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	_ "github.com/bill-rich/cncstats/docs"
 	"github.com/bill-rich/cncstats/pkg/bitparse"
 	"github.com/bill-rich/cncstats/pkg/iniparse"
+	"github.com/bill-rich/cncstats/pkg/mapfile"
 	"github.com/bill-rich/cncstats/pkg/statsfile"
 	"github.com/bill-rich/cncstats/pkg/zhreplay"
 	"github.com/gin-gonic/gin"
@@ -236,6 +239,11 @@ func startWebServer(objectStore *iniparse.ObjectStore, powerStore *iniparse.Powe
 		uploadStatsHandler(c)
 	})
 
+	// Map endpoints
+	router.GET("/map_exists", mapExistsHandler)
+	router.POST("/add_map", addMapHandler)
+	router.GET("/get_map", getMapHandler)
+
 	// Swagger UI (serves Swagger 2.0 interactive docs)
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
@@ -366,4 +374,174 @@ func uploadStatsHandler(c *gin.Context) {
 		"seed":    seed,
 		"size":    len(data),
 	})
+}
+
+// mapExistsHandler reports whether the server already has a map for the
+// given CRC.
+// @Summary Check whether a map exists on the server
+// @Description Returns plain-text "true" if a .map file is already stored under MAPS_DIR for the given crc, "false" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.
+// @Tags maps
+// @Produce plain
+// @Param crc query string true "Map CRC (decimal, as emitted by MapMetaData::m_CRC)"
+// @Success 200 {string} string "\"true\" or \"false\""
+// @Failure 400 {object} ErrorResponse
+// @Router /map_exists [get]
+func mapExistsHandler(c *gin.Context) {
+	crc := c.Query("crc")
+	if crc == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "crc query parameter is required",
+		})
+		return
+	}
+
+	answer := "false"
+	if mapfile.Exists(crc) {
+		answer = "true"
+	}
+	c.Header("Content-Type", "text/plain; charset=utf-8")
+	c.String(http.StatusOK, answer)
+}
+
+// addMapHandler ingests one map asset (either the .map file or its .tga
+// preview) and writes it into MAPS_DIR/<crc>/. The Generals client makes
+// two POST requests per map — one with X-Map-File: map and one with
+// X-Map-File: preview — both carrying the same X-Map-CRC.
+// @Summary Upload a map asset (.map or .tga preview)
+// @Description Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.
+// @Tags maps
+// @Accept octet-stream
+// @Produce json
+// @Param X-Map-CRC header string true "Map CRC (decimal); identifies the map"
+// @Param X-Map-Name header string false "Original map path/name from the game (e.g. \"Maps\\Tournament Desert\\Tournament Desert.map\")"
+// @Param X-Map-File header string true "Asset kind: \"map\" or \"preview\""
+// @Param X-Game-Seed header string false "Game seed for telemetry correlation"
+// @Success 200 {object} map[string]any
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /add_map [post]
+func addMapHandler(c *gin.Context) {
+	crc := c.GetHeader("X-Map-CRC")
+	if crc == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "X-Map-CRC header is required",
+		})
+		return
+	}
+	kind := c.GetHeader("X-Map-File")
+	if kind != mapfile.KindMap && kind != mapfile.KindPreview {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error":   "X-Map-File header must be \"map\" or \"preview\"",
+			"details": fmt.Sprintf("got %q", kind),
+		})
+		return
+	}
+	mapName := c.GetHeader("X-Map-Name")
+
+	data, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to read request body",
+			"details": err.Error(),
+		})
+		return
+	}
+	if len(data) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "Empty request body",
+		})
+		return
+	}
+
+	if err := mapfile.Store(crc, mapName, kind, data); err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to store map asset",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"crc":  crc,
+		"kind": kind,
+		"size": len(data),
+		"name": mapName,
+	}).Info("Map asset stored")
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Map asset stored successfully",
+		"crc":     crc,
+		"kind":    kind,
+		"size":    len(data),
+	})
+}
+
+// getMapHandler returns a zip archive containing the .map file and (if
+// stored) the .tga preview for the given CRC. Entries inside the zip are
+// renamed to use the basename from the original X-Map-Name so the zip
+// can be extracted directly into a Maps/<dir>/ folder.
+// @Summary Download the map and preview as a zip
+// @Description Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.
+// @Tags maps
+// @Produce application/zip
+// @Param crc query string true "Map CRC (decimal)"
+// @Success 200 {file} file "Zip archive (application/zip)"
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /get_map [get]
+func getMapHandler(c *gin.Context) {
+	crc := c.Query("crc")
+	if crc == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "crc query parameter is required",
+		})
+		return
+	}
+
+	mapName, mapData, previewData, err := mapfile.Load(crc)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+				"error": "no map stored for that crc",
+				"crc":   crc,
+			})
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to load map",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	// Build the zip in memory; map files plus a preview are typically a
+	// few hundred KB at most, so streaming buys nothing here.
+	base := mapfile.BaseName(mapName)
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	mapEntry, err := zw.Create(base + ".map")
+	if err == nil {
+		_, err = mapEntry.Write(mapData)
+	}
+	if err == nil && previewData != nil {
+		var previewEntry io.Writer
+		previewEntry, err = zw.Create(base + ".tga")
+		if err == nil {
+			_, err = previewEntry.Write(previewData)
+		}
+	}
+	if err == nil {
+		err = zw.Close()
+	}
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to build zip archive",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", base+".zip"))
+	c.Data(http.StatusOK, "application/zip", buf.Bytes())
 }

--- a/pkg/iniparse/iniparse.go
+++ b/pkg/iniparse/iniparse.go
@@ -412,8 +412,18 @@ func (c *ColorStore) GetColorName(i int) (string, error) {
 }
 
 func (c *ColorStore) loadColors(dir string) error {
-	file, err := os.Open(dir + "/multiplayer.ini")
+	if err := c.loadColorFile(dir+"/multiplayer.ini", true); err != nil {
+		return err
+	}
+	return c.loadColorFile(dir+"/ZuluColors.ini", false)
+}
+
+func (c *ColorStore) loadColorFile(path string, required bool) error {
+	file, err := os.Open(path)
 	if err != nil {
+		if !required && os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	defer file.Close()

--- a/pkg/mapfile/mapfile.go
+++ b/pkg/mapfile/mapfile.go
@@ -1,0 +1,152 @@
+// Package mapfile persists Generals .map files (and their .tga previews)
+// keyed by the .map's CRC, mirroring the on-disk pattern used by
+// pkg/statsfile.
+//
+// Layout under MapsDir:
+//
+//	<crc>/
+//	  meta.txt        # one line: original X-Map-Name from the upload (e.g. "Maps\Tournament Desert\Tournament Desert.map")
+//	  map.map         # the .map file bytes
+//	  preview.tga     # the .tga preview bytes (optional; may not exist)
+//
+// Existence is checked by the directory: if "<MapsDir>/<crc>" exists, we
+// already have that map.
+package mapfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MapsDir is the directory where map files are stored.
+// Set via MAPS_DIR env var or defaults to ./maps/
+var MapsDir = "./maps"
+
+func init() {
+	if dir := os.Getenv("MAPS_DIR"); dir != "" {
+		MapsDir = dir
+	}
+}
+
+// File-kind constants matching the X-Map-File header values sent by the
+// game's StatsUploader.
+const (
+	KindMap     = "map"
+	KindPreview = "preview"
+)
+
+// On-disk filenames for the two assets. Fixed names so existence checks
+// don't depend on map naming conventions; the original name is preserved
+// in meta.txt for /get_map.
+const (
+	mapFilename     = "map.map"
+	previewFilename = "preview.tga"
+	metaFilename    = "meta.txt"
+)
+
+// MapDir returns the per-CRC storage directory for a given CRC.
+func MapDir(crc string) string {
+	return filepath.Join(MapsDir, crc)
+}
+
+// Exists reports whether we already have any files for this CRC. A
+// directory with at least the .map file present counts as "have it".
+func Exists(crc string) bool {
+	if crc == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(MapDir(crc), mapFilename))
+	return err == nil && info.Mode().IsRegular()
+}
+
+// Store writes one asset (the .map or its .tga preview) into the CRC dir
+// and refreshes meta.txt with the supplied original map name. kind must
+// be either KindMap or KindPreview. Calling Store with the same kind
+// twice overwrites silently.
+func Store(crc string, mapName string, kind string, data []byte) error {
+	if crc == "" {
+		return errors.New("mapfile.Store: empty crc")
+	}
+	target, err := assetFilename(kind)
+	if err != nil {
+		return err
+	}
+
+	dir := MapDir(crc)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create map dir: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, target), data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+
+	// Refresh meta.txt with the most recent name we've seen for this CRC.
+	// In normal operation both POSTs for the same map carry the same
+	// X-Map-Name, so this is just idempotent overwrite.
+	if mapName != "" {
+		if err := os.WriteFile(filepath.Join(dir, metaFilename), []byte(mapName), 0644); err != nil {
+			return fmt.Errorf("write meta: %w", err)
+		}
+	}
+	return nil
+}
+
+// Load returns the stored map name (from meta.txt), the .map bytes, and
+// the .tga preview bytes for the given CRC. previewData is nil when the
+// preview wasn't uploaded. Returns os.ErrNotExist if the .map is missing.
+func Load(crc string) (mapName string, mapData []byte, previewData []byte, err error) {
+	if crc == "" {
+		return "", nil, nil, errors.New("mapfile.Load: empty crc")
+	}
+	dir := MapDir(crc)
+
+	mapData, err = os.ReadFile(filepath.Join(dir, mapFilename))
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	if metaBytes, metaErr := os.ReadFile(filepath.Join(dir, metaFilename)); metaErr == nil {
+		mapName = strings.TrimSpace(string(metaBytes))
+	}
+
+	if previewBytes, previewErr := os.ReadFile(filepath.Join(dir, previewFilename)); previewErr == nil {
+		previewData = previewBytes
+	}
+	return mapName, mapData, previewData, nil
+}
+
+// BaseName extracts the filename stem from an original X-Map-Name. The
+// game sends paths with backslashes (e.g. "Maps\Foo\Foo.map"); we want
+// "Foo" so /get_map can rename the zip entries to "Foo.map" / "Foo.tga".
+func BaseName(mapName string) string {
+	if mapName == "" {
+		return "map"
+	}
+	// Strip directory components for both separators (Windows + POSIX).
+	cleaned := strings.ReplaceAll(mapName, "\\", "/")
+	last := filepath.Base(cleaned)
+	// Strip extension.
+	if dot := strings.LastIndex(last, "."); dot > 0 {
+		last = last[:dot]
+	}
+	if last == "" {
+		return "map"
+	}
+	return last
+}
+
+// assetFilename maps an X-Map-File header value to the on-disk filename.
+func assetFilename(kind string) (string, error) {
+	switch kind {
+	case KindMap:
+		return mapFilename, nil
+	case KindPreview:
+		return previewFilename, nil
+	default:
+		return "", fmt.Errorf("mapfile: unknown X-Map-File kind %q", kind)
+	}
+}

--- a/pkg/zhreplay/enhanced_replay_v2.go
+++ b/pkg/zhreplay/enhanced_replay_v2.go
@@ -269,8 +269,106 @@ func ConvertToEnhancedReplayV2(replay *Replay, stats *statsfile.GameStats, objec
 
 	// Determine winners using death events from stats
 	v2.DetermineWinnersByDeathEvents(objectStore)
+	v2.applyHumansVsCPUFlip()
 
 	return v2
+}
+
+// isAI reports whether a v2 player slot is an AI.
+func (p *PlayerSummaryV2) isAI() bool {
+	return p.PlayerType == "C" || p.PlayerType == "Computer"
+}
+
+// applyHumansVsCPUFlip credits an all-human team with the win when the
+// apparent winning team is a mix of humans and CPUs whose humans were all
+// dead before the all-human opposing team surrendered. Mirrors the logic in
+// (*Replay).applyHumansVsCPUFlip but uses death events from the stats file
+// in addition to surrender commands from the body.
+func (v2 *EnhancedReplayV2) applyHumansVsCPUFlip() {
+	teamMembers := map[int][]*PlayerSummaryV2{}
+	for _, p := range v2.Summary {
+		if p.Side == "Observer" {
+			continue
+		}
+		teamMembers[p.Team] = append(teamMembers[p.Team], p)
+	}
+
+	winningTeam := -1
+	for team, members := range teamMembers {
+		if len(members) > 0 && members[0].Win {
+			if winningTeam != -1 {
+				return
+			}
+			winningTeam = team
+		}
+	}
+	if winningTeam == -1 {
+		return
+	}
+
+	var winningHumans []*PlayerSummaryV2
+	winnersHaveCPU := false
+	for _, p := range teamMembers[winningTeam] {
+		if p.isAI() {
+			winnersHaveCPU = true
+		} else {
+			winningHumans = append(winningHumans, p)
+		}
+	}
+	if !winnersHaveCPU || len(winningHumans) == 0 {
+		return
+	}
+
+	for team, members := range teamMembers {
+		if team == winningTeam {
+			continue
+		}
+		for _, p := range members {
+			if p.isAI() {
+				return
+			}
+		}
+	}
+
+	deadPlayers := map[int]bool{}
+	if v2.Stats != nil {
+		for _, de := range v2.Stats.DeathEvents {
+			deadPlayers[de.Player] = true
+		}
+	}
+	for _, p := range winningHumans {
+		if !deadPlayers[p.Index] {
+			return
+		}
+	}
+
+	losingHuman := map[string]bool{}
+	for team, members := range teamMembers {
+		if team == winningTeam {
+			continue
+		}
+		for _, p := range members {
+			losingHuman[p.Name] = true
+		}
+	}
+	losingSurrendered := false
+	for _, c := range v2.Body {
+		if c.OrderCode == 1093 && losingHuman[c.PlayerName] {
+			losingSurrendered = true
+			break
+		}
+	}
+	if !losingSurrendered {
+		return
+	}
+
+	for _, p := range v2.Summary {
+		if p.Side == "Observer" {
+			continue
+		}
+		p.Win = p.Team != winningTeam
+	}
+	v2.WinMethod = "humansVsCPU"
 }
 
 // DetermineWinnersByDeathEvents uses the stats death events to determine winners.

--- a/pkg/zhreplay/enhanced_replay_v2.go
+++ b/pkg/zhreplay/enhanced_replay_v2.go
@@ -14,6 +14,34 @@ const (
 	EnhancedReplayVersionV2 = 2
 )
 
+// sideToFriendly translates the machine-readable Side values from the stats
+// JSON (PlayerTemplate.ini's Side field) to the friendly forms previously
+// produced by constructorMap during replay-only parsing.
+var sideToFriendly = map[string]string{
+	"America":                   "USA",
+	"AmericaAirForceGeneral":    "USA Airforce",
+	"AmericaLaserGeneral":       "USA Lazr",
+	"AmericaSuperWeaponGeneral": "USA Superweapon",
+	"China":                     "China",
+	"ChinaInfantryGeneral":      "China Infantry",
+	"ChinaNukeGeneral":          "China Nuke",
+	"ChinaTankGeneral":          "China Tank",
+	"GLA":                       "GLA",
+	"GLADemolitionGeneral":      "GLA Demo",
+	"GLAStealthGeneral":         "GLA Stealth",
+	"GLAToxinGeneral":           "GLA Toxin",
+	"Boss":                      "Boss",
+	"Observer":                  "Observer",
+	"Civilian":                  "Civilian",
+}
+
+func friendlySide(s string) string {
+	if friendly, ok := sideToFriendly[s]; ok {
+		return friendly
+	}
+	return s
+}
+
 // WinEstimation holds the estimated winner result and per-team breakdown.
 type WinEstimation struct {
 	Confidence   float64              `json:"confidence"`
@@ -204,23 +232,39 @@ func ConvertToEnhancedReplayV2(replay *Replay, stats *statsfile.GameStats, objec
 		}
 	}
 
-	// Merge stats player data into summary entries
-	for _, sp := range stats.Players {
-		for _, p := range v2.Summary {
-			if sp.DisplayName == p.Name || sp.Side == p.Side {
-				p.Index = sp.Index
-				p.PlayerType = sp.Type
-				p.Color = sp.Color
-				p.Faction = sp.Faction
-				p.BaseSide = sp.BaseSide
-				p.Money = sp.Money
-				p.MoneyEarned = sp.MoneyEarned
-				p.MoneySpent = sp.MoneySpent
-				p.Score = sp.Score
-				p.Academy = sp.Academy
-				break
-			}
+	// Merge stats player data into summary entries by positional index.
+	// stats.Players uses 1-based indices that line up with non-observer
+	// slots in v2.Summary (which preserves header.Metadata.Players order).
+	// Positional matching is reliable for both humans and AI; AI players
+	// have no Name in the replay header, so name/side joins don't work.
+	nonObservers := make([]*PlayerSummaryV2, 0, len(v2.Summary))
+	for _, p := range v2.Summary {
+		if p.Side == "Observer" {
+			continue
 		}
+		nonObservers = append(nonObservers, p)
+	}
+
+	for _, sp := range stats.Players {
+		idx := sp.Index - 1
+		if idx < 0 || idx >= len(nonObservers) {
+			continue
+		}
+		p := nonObservers[idx]
+		if p.Name == "" {
+			p.Name = sp.DisplayName
+		}
+		p.Side = friendlySide(sp.Side)
+		p.BaseSide = sp.BaseSide
+		p.Index = sp.Index
+		p.PlayerType = sp.Type
+		p.Color = sp.Color
+		p.Faction = sp.Faction
+		p.Money = sp.Money
+		p.MoneyEarned = sp.MoneyEarned
+		p.MoneySpent = sp.MoneySpent
+		p.Score = sp.Score
+		p.Academy = sp.Academy
 	}
 
 	// Determine winners using death events from stats

--- a/pkg/zhreplay/object/object.go
+++ b/pkg/zhreplay/object/object.go
@@ -34,6 +34,7 @@ type PlayerSummary struct {
 	Side           string                    `json:"side"`
 	Team           int                       `json:"team"`
 	Win            bool                      `json:"win"`
+	IsAI           bool                      `json:"isAI"`
 	MoneySpent     int                       `json:"moneySpent"`
 	UnitsCreated   map[string]*ObjectSummary `json:"unitsCreated"`
 	BuildingsBuilt map[string]*ObjectSummary `json:"buildingsBuilt"`

--- a/pkg/zhreplay/zhreplay.go
+++ b/pkg/zhreplay/zhreplay.go
@@ -72,6 +72,7 @@ func (r *Replay) CreatePlayerList() {
 			Name:           playerMd.Name,
 			Team:           team,
 			Win:            true,
+			IsAI:           playerMd.Type == "C",
 			BuildingsBuilt: map[string]*object.ObjectSummary{},
 			UnitsCreated:   map[string]*object.ObjectSummary{},
 			UpgradesBuilt:  map[string]*object.ObjectSummary{},
@@ -152,6 +153,93 @@ func (r *Replay) GenerateData() {
 	}
 
 	r.fallbackWinnerDetection()
+	r.applyHumansVsCPUFlip()
+}
+
+// applyHumansVsCPUFlip credits an all-human team with the win when the
+// apparent winning team is a mix of humans and CPUs whose humans were all
+// defeated (or surrendered) before the all-human opposing team surrendered.
+// People surrender in this situation because fighting an all-CPU remnant is
+// boring, so the humans should not be marked as losers for giving up.
+func (r *Replay) applyHumansVsCPUFlip() {
+	teamMembers := map[int][]*object.PlayerSummary{}
+	for _, p := range r.Summary {
+		if p.Team == -1 {
+			continue
+		}
+		teamMembers[p.Team] = append(teamMembers[p.Team], p)
+	}
+
+	winningTeam := -1
+	for team, members := range teamMembers {
+		if len(members) > 0 && members[0].Win {
+			if winningTeam != -1 {
+				return
+			}
+			winningTeam = team
+		}
+	}
+	if winningTeam == -1 {
+		return
+	}
+
+	var winningHumans []*object.PlayerSummary
+	winnersHaveCPU := false
+	for _, p := range teamMembers[winningTeam] {
+		if p.IsAI {
+			winnersHaveCPU = true
+		} else {
+			winningHumans = append(winningHumans, p)
+		}
+	}
+	if !winnersHaveCPU || len(winningHumans) == 0 {
+		return
+	}
+
+	for team, members := range teamMembers {
+		if team == winningTeam {
+			continue
+		}
+		for _, p := range members {
+			if p.IsAI {
+				return
+			}
+		}
+	}
+
+	earliestSurrender := -1
+	lastActivity := map[string]int{}
+	for _, c := range r.Body {
+		if c.OrderCode == 1093 {
+			for _, p := range r.Summary {
+				if p.Name == c.PlayerName && p.Team != winningTeam && p.Team != -1 {
+					if earliestSurrender == -1 || c.TimeCode < earliestSurrender {
+						earliestSurrender = c.TimeCode
+					}
+					break
+				}
+			}
+		}
+		if !body.PassiveCommands[c.OrderCode] && c.TimeCode > lastActivity[c.PlayerName] {
+			lastActivity[c.PlayerName] = c.TimeCode
+		}
+	}
+	if earliestSurrender == -1 {
+		return
+	}
+	for _, p := range winningHumans {
+		if lastActivity[p.Name] >= earliestSurrender {
+			return
+		}
+	}
+
+	for _, p := range r.Summary {
+		if p.Team == -1 {
+			continue
+		}
+		p.Win = p.Team != winningTeam
+	}
+	r.WinMethod = "humansVsCPU"
 }
 
 // fallbackWinnerDetection determines the winner from replay commands.


### PR DESCRIPTION
## Summary

Five commits, oldest first:

- **Map storage support** (1ad0d0f): adds `pkg/mapfile` for parsing Generals map files plus the HTTP plumbing (`main.go`, docker-compose, swagger/openapi docs) to upload, store, and serve them.
- **Load ZuluColors.ini alongside multiplayer.ini** (ff36b37): `pkg/iniparse` accepts a second optional color INI so mod-shipped `MultiplayerColor` entries are appended to the `ColorStore` without modifying the base file.
- **Populate side and stats fields for AI players in v2 summary** (29349e8): match stats players to v2 summary entries positionally instead of by name/side, since AI players have neither in the replay header. Stats `Side` values (e.g. `ChinaNukeGeneral`) are translated back to the friendly forms (`China Nuke`) previously produced by `constructorMap`.
- **ZuluColors.ini cleanup** (f63836d): rename color identifiers to match the base `multiplayer.ini` convention (`ColorMaroon`, `ColorLime`, `ColorBrown`, `ColorBlack`); replace `Silver` with `ColorMetallicGrey` (#708090).
- **Credit humans with the win when only CPUs remain on the opposing team** (52a88cc): when the apparent winning team is a mix of humans and CPUs whose humans were all defeated/surrendered before the all-human opposing team surrendered, flip the result so the humans are marked as winners. Applied in both `Replay.fallbackWinnerDetection` and `EnhancedReplayV2.DetermineWinnersByDeathEvents`, with `WinMethod` set to `humansVsCPU` to make the source traceable.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Upload a map via the new endpoint and re-fetch it
- [ ] Parse a replay using mod-shipped colors and confirm `ColorStore` resolves them
- [ ] Parse a replay with AI players and confirm v2 summary has populated `Side`, `Faction`, `MoneyEarned`, etc.
- [ ] Parse a replay where humans surrender to a mixed humans+CPU team after the opposing humans were defeated; confirm `WinMethod` is `humansVsCPU` and the surrendering humans are marked as winners
- [ ] Parse a normal humans-vs-humans replay and confirm winner detection is unchanged