### PR TITLE
Add API key authentication for write endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: test
+.PHONY: test docs
 
 test:
 	go test -timeout=5m $(shell go list ./...)
+
+# Regenerate API docs: Swagger 2.0 from code annotations, then OpenAPI v3.
+# The pinned swag version is run module-isolated (the @version form) so its
+# CLI-only dependencies don't have to be tracked in this module's go.sum.
+SWAG_VERSION := v1.16.6
+docs:
+	go run github.com/swaggo/swag/cmd/swag@$(SWAG_VERSION) init --parseDependency --parseInternal
+	go run ./cmd/swagger2openapi

--- a/README.md
+++ b/README.md
@@ -130,6 +130,57 @@ Upload a replay file:
 curl -X POST -F "file=@replay.rep" http://localhost:8080/replay
 ```
 
+### Authentication
+
+The **write** endpoints (`POST /replay`, `POST /stats`, `POST /add_map`) can be
+protected with API keys. The **read** endpoints (`/map_exists`, `/get_map`,
+`/get_map_file`, `/list_map_assets`) and the docs are always open, since game
+peers need them mid-lobby.
+
+Auth is controlled by two environment variables:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `CNC_AUTH_REQUIRED` | Whether write endpoints require a key. Set to `false`/`0` to disable; any other value (or unset) enforces auth. | `true` |
+| `CNC_API_KEYS` | Comma-separated list of `name:key` pairs. The name is for logging only; the key is the secret. | — |
+
+Configure one key per client. Add, replace, or remove clients by editing
+`CNC_API_KEYS` and restarting — no code change required:
+
+```bash
+export CNC_AUTH_REQUIRED=true
+export CNC_API_KEYS="zulu:$(openssl rand -hex 32),radarvan:$(openssl rand -hex 32),dev:dev-local-key"
+./cncstats
+```
+
+When `CNC_AUTH_REQUIRED` is `true` but `CNC_API_KEYS` has no valid entries, the
+server refuses to start (nobody could authenticate). Malformed entries (missing
+`:`, empty name or key) are logged and skipped.
+
+Clients send the key as a bearer token or in the `X-API-Key` header:
+
+```bash
+# Authorization: Bearer
+curl -X POST -F "file=@replay.rep" \
+  -H "Authorization: Bearer <key>" \
+  http://localhost:8080/replay
+
+# X-API-Key
+curl -X POST --data-binary @stats.json.gz \
+  -H "X-API-Key: <key>" \
+  -H "X-Game-Seed: 12345" \
+  http://localhost:8080/stats
+```
+
+Requests with a missing or invalid key get `401 {"error":"invalid or missing API key"}`.
+
+For local development, disable auth entirely:
+
+```bash
+export CNC_AUTH_REQUIRED=false
+./cncstats
+```
+
 ## Docker
 
 Build the image:

--- a/cmd/swagger2openapi/main.go
+++ b/cmd/swagger2openapi/main.go
@@ -73,15 +73,23 @@ func convert(swagger map[string]interface{}) map[string]interface{} {
 		openapi["paths"] = convertPaths(paths)
 	}
 
-	// Convert definitions → components/schemas
+	// Convert definitions → components/schemas and securityDefinitions →
+	// components/securitySchemes. Both live under components in OpenAPI v3.
+	components := map[string]interface{}{}
 	if defs, ok := swagger["definitions"].(map[string]interface{}); ok {
 		schemas := make(map[string]interface{})
 		for name, schema := range defs {
 			schemas[name] = convertSchema(schema)
 		}
-		openapi["components"] = map[string]interface{}{
-			"schemas": schemas,
-		}
+		components["schemas"] = schemas
+	}
+	if secDefs, ok := swagger["securityDefinitions"].(map[string]interface{}); ok {
+		// apiKey schemes are identical between Swagger 2.0 and OpenAPI 3, so
+		// copy them through as-is.
+		components["securitySchemes"] = secDefs
+	}
+	if len(components) > 0 {
+		openapi["components"] = components
 	}
 
 	return openapi
@@ -111,8 +119,9 @@ func convertOperation(op interface{}) map[string]interface{} {
 
 	result := make(map[string]interface{})
 
-	// Copy simple fields
-	for _, key := range []string{"summary", "description", "tags", "operationId"} {
+	// Copy simple fields. The security requirement format is unchanged
+	// between Swagger 2.0 and OpenAPI 3, so it passes through as-is.
+	for _, key := range []string{"summary", "description", "tags", "operationId", "security"} {
 		if v, ok := opMap[key]; ok {
 			result[key] = v
 		}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -17,7 +17,15 @@ const docTemplate = `{
     "paths": {
         "/add_map": {
             "post": {
-                "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Stores one asset that makes up a map, keyed by X-Map-CRC. Supported X-Map-File values: \"map\", \"preview\", \"ini\", \"str\", \"solo\", \"assets\", \"readme\". Identical CRCs overwrite silently.",
                 "consumes": [
                     "application/octet-stream"
                 ],
@@ -27,7 +35,7 @@ const docTemplate = `{
                 "tags": [
                     "maps"
                 ],
-                "summary": "Upload a map asset (.map or .tga preview)",
+                "summary": "Upload a map asset (.map / .tga / sidecar)",
                 "parameters": [
                     {
                         "type": "string",
@@ -66,6 +74,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -126,6 +140,96 @@ const docTemplate = `{
                 }
             }
         },
+        "/get_map_file": {
+            "get": {
+                "description": "Returns raw bytes for one stored asset kind. 404 if either the CRC isn't known or that kind wasn't uploaded.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Download a single map asset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Asset kind: \\",
+                        "name": "kind",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw asset bytes (application/octet-stream)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/list_map_assets": {
+            "get": {
+                "description": "Returns JSON: {\"crc\": \"...\", \"name\": \"...\", \"kinds\": [\"map\",\"preview\",\"ini\",...]}. Empty kinds array if the CRC is unknown.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "List stored asset kinds for a CRC",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/map_exists": {
             "get": {
                 "description": "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.",
@@ -163,6 +267,14 @@ const docTemplate = `{
         },
         "/replay": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
                 "description": "Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.",
                 "consumes": [
                     "multipart/form-data"
@@ -196,6 +308,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -207,6 +325,14 @@ const docTemplate = `{
         },
         "/stats": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
                 "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.",
                 "consumes": [
                     "application/octet-stream"
@@ -236,6 +362,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -1103,6 +1235,20 @@ const docTemplate = `{
                     "type": "integer"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "ApiKeyAuth": {
+            "description": "API key supplied in the X-API-Key header. Alternative to the Authorization header.",
+            "type": "apiKey",
+            "name": "X-API-Key",
+            "in": "header"
+        },
+        "BearerAuth": {
+            "description": "API key supplied as \"Bearer \u003ckey\u003e\". Required on write endpoints when CNC_AUTH_REQUIRED is true.",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }`

--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -854,6 +854,20 @@
         },
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "description": "API key supplied in the X-API-Key header. Alternative to the Authorization header.",
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
+      },
+      "BearerAuth": {
+        "description": "API key supplied as \"Bearer \u003ckey\u003e\". Required on write endpoints when CNC_AUTH_REQUIRED is true.",
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      }
     }
   },
   "info": {
@@ -866,7 +880,7 @@
   "paths": {
     "/add_map": {
       "post": {
-        "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+        "description": "Stores one asset that makes up a map, keyed by X-Map-CRC. Supported X-Map-File values: \"map\", \"preview\", \"ini\", \"str\", \"solo\", \"assets\", \"readme\". Identical CRCs overwrite silently.",
         "parameters": [
           {
             "description": "Map CRC (decimal); identifies the map",
@@ -936,6 +950,16 @@
             },
             "description": "Bad Request"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -947,7 +971,15 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Upload a map asset (.map or .tga preview)",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Upload a map asset (.map / .tga / sidecar)",
         "tags": [
           "maps"
         ]
@@ -1010,6 +1042,120 @@
           }
         },
         "summary": "Download the map and preview as a zip",
+        "tags": [
+          "maps"
+        ]
+      }
+    },
+    "/get_map_file": {
+      "get": {
+        "description": "Returns raw bytes for one stored asset kind. 404 if either the CRC isn't known or that kind wasn't uploaded.",
+        "parameters": [
+          {
+            "description": "Map CRC (decimal)",
+            "in": "query",
+            "name": "crc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Asset kind: \\",
+            "in": "query",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "file"
+                }
+              }
+            },
+            "description": "Raw asset bytes (application/octet-stream)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Download a single map asset",
+        "tags": [
+          "maps"
+        ]
+      }
+    },
+    "/list_map_assets": {
+      "get": {
+        "description": "Returns JSON: {\"crc\": \"...\", \"name\": \"...\", \"kinds\": [\"map\",\"preview\",\"ini\",...]}. Empty kinds array if the CRC is unknown.",
+        "parameters": [
+          {
+            "description": "Map CRC (decimal)",
+            "in": "query",
+            "name": "crc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          }
+        },
+        "summary": "List stored asset kinds for a CRC",
         "tags": [
           "maps"
         ]
@@ -1101,6 +1247,16 @@
             },
             "description": "Bad Request"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -1112,6 +1268,14 @@
             "description": "Internal Server Error"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Parse a replay file",
         "tags": [
           "replay"
@@ -1164,6 +1328,16 @@
             },
             "description": "Bad Request"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -1175,6 +1349,14 @@
             "description": "Internal Server Error"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Upload game stats",
         "tags": [
           "stats"

--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -577,6 +577,17 @@ components:
           description: total active factors (3 or 4)
           type: integer
       type: object
+  securitySchemes:
+    ApiKeyAuth:
+      description: API key supplied in the X-API-Key header. Alternative to the Authorization header.
+      in: header
+      name: X-API-Key
+      type: apiKey
+    BearerAuth:
+      description: "API key supplied as \"Bearer \u003ckey\u003e\". Required on write endpoints when CNC_AUTH_REQUIRED is true."
+      in: header
+      name: Authorization
+      type: apiKey
 info:
   contact:
 {}
@@ -587,7 +598,7 @@ openapi: 3.0.3
 paths:
   /add_map:
     post:
-      description: Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.
+      description: "Stores one asset that makes up a map, keyed by X-Map-CRC. Supported X-Map-File values: \"map\", \"preview\", \"ini\", \"str\", \"solo\", \"assets\", \"readme\". Identical CRCs overwrite silently."
       parameters:
         - description: Map CRC (decimal); identifies the map
           in: header
@@ -632,13 +643,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Bad Request
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Unauthorized
         500:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Internal Server Error
-      summary: Upload a map asset (.map or .tga preview)
+      security:
+        - BearerAuth:
+            []
+        - ApiKeyAuth:
+            []
+      summary: Upload a map asset (.map / .tga / sidecar)
       tags:
         - maps
   /get_map:
@@ -677,6 +699,77 @@ paths:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Internal Server Error
       summary: Download the map and preview as a zip
+      tags:
+        - maps
+  /get_map_file:
+    get:
+      description: "Returns raw bytes for one stored asset kind. 404 if either the CRC isn't known or that kind wasn't uploaded."
+      parameters:
+        - description: Map CRC (decimal)
+          in: query
+          name: crc
+          required: true
+          schema:
+            type: string
+        - description: "Asset kind: \\"
+          in: query
+          name: kind
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: file
+          description: Raw asset bytes (application/octet-stream)
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Not Found
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Internal Server Error
+      summary: Download a single map asset
+      tags:
+        - maps
+  /list_map_assets:
+    get:
+      description: "Returns JSON: {\"crc\": \"...\", \"name\": \"...\", \"kinds\": [\"map\",\"preview\",\"ini\",...]}. Empty kinds array if the CRC is unknown."
+      parameters:
+        - description: Map CRC (decimal)
+          in: query
+          name: crc
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+          description: OK
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+      summary: List stored asset kinds for a CRC
       tags:
         - maps
   /map_exists:
@@ -734,12 +827,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Bad Request
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Unauthorized
         500:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Internal Server Error
+      security:
+        - BearerAuth:
+            []
+        - ApiKeyAuth:
+            []
       summary: Parse a replay file
       tags:
         - replay
@@ -773,12 +877,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Bad Request
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Unauthorized
         500:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Internal Server Error
+      security:
+        - BearerAuth:
+            []
+        - ApiKeyAuth:
+            []
       summary: Upload game stats
       tags:
         - stats

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11,7 +11,15 @@
     "paths": {
         "/add_map": {
             "post": {
-                "description": "Stores one of the two assets that make up a map (the .map file or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently. Two calls (one per asset kind) are expected per map.",
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Stores one asset that makes up a map, keyed by X-Map-CRC. Supported X-Map-File values: \"map\", \"preview\", \"ini\", \"str\", \"solo\", \"assets\", \"readme\". Identical CRCs overwrite silently.",
                 "consumes": [
                     "application/octet-stream"
                 ],
@@ -21,7 +29,7 @@
                 "tags": [
                     "maps"
                 ],
-                "summary": "Upload a map asset (.map or .tga preview)",
+                "summary": "Upload a map asset (.map / .tga / sidecar)",
                 "parameters": [
                     {
                         "type": "string",
@@ -60,6 +68,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -120,6 +134,96 @@
                 }
             }
         },
+        "/get_map_file": {
+            "get": {
+                "description": "Returns raw bytes for one stored asset kind. 404 if either the CRC isn't known or that kind wasn't uploaded.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Download a single map asset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Asset kind: \\",
+                        "name": "kind",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw asset bytes (application/octet-stream)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/list_map_assets": {
+            "get": {
+                "description": "Returns JSON: {\"crc\": \"...\", \"name\": \"...\", \"kinds\": [\"map\",\"preview\",\"ini\",...]}. Empty kinds array if the CRC is unknown.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "List stored asset kinds for a CRC",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Map CRC (decimal)",
+                        "name": "crc",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/map_exists": {
             "get": {
                 "description": "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map.",
@@ -157,6 +261,14 @@
         },
         "/replay": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
                 "description": "Upload a .rep replay file and receive parsed replay data in v2 format. Stats fields are populated when a matching stats file exists.",
                 "consumes": [
                     "multipart/form-data"
@@ -190,6 +302,12 @@
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -201,6 +319,14 @@
         },
         "/stats": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
                 "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.",
                 "consumes": [
                     "application/octet-stream"
@@ -230,6 +356,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -1097,6 +1229,20 @@
                     "type": "integer"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "ApiKeyAuth": {
+            "description": "API key supplied in the X-API-Key header. Alternative to the Authorization header.",
+            "type": "apiKey",
+            "name": "X-API-Key",
+            "in": "header"
+        },
+        "BearerAuth": {
+            "description": "API key supplied as \"Bearer \u003ckey\u003e\". Required on write endpoints when CNC_AUTH_REQUIRED is true.",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -586,9 +586,9 @@ paths:
     post:
       consumes:
       - application/octet-stream
-      description: Stores one of the two assets that make up a map (the .map file
-        or its .tga preview) keyed by X-Map-CRC. Identical CRCs overwrite silently.
-        Two calls (one per asset kind) are expected per map.
+      description: 'Stores one asset that makes up a map, keyed by X-Map-CRC. Supported
+        X-Map-File values: "map", "preview", "ini", "str", "solo", "assets", "readme".
+        Identical CRCs overwrite silently.'
       parameters:
       - description: Map CRC (decimal); identifies the map
         in: header
@@ -620,11 +620,18 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/main.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/main.ErrorResponse'
-      summary: Upload a map asset (.map or .tga preview)
+      security:
+      - BearerAuth: []
+      - ApiKeyAuth: []
+      summary: Upload a map asset (.map / .tga / sidecar)
       tags:
       - maps
   /get_map:
@@ -658,6 +665,68 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Download the map and preview as a zip
+      tags:
+      - maps
+  /get_map_file:
+    get:
+      description: Returns raw bytes for one stored asset kind. 404 if either the
+        CRC isn't known or that kind wasn't uploaded.
+      parameters:
+      - description: Map CRC (decimal)
+        in: query
+        name: crc
+        required: true
+        type: string
+      - description: 'Asset kind: \'
+        in: query
+        name: kind
+        required: true
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: Raw asset bytes (application/octet-stream)
+          schema:
+            type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Download a single map asset
+      tags:
+      - maps
+  /list_map_assets:
+    get:
+      description: 'Returns JSON: {"crc": "...", "name": "...", "kinds": ["map","preview","ini",...]}.
+        Empty kinds array if the CRC is unknown.'
+      parameters:
+      - description: Map CRC (decimal)
+        in: query
+        name: crc
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: List stored asset kinds for a CRC
       tags:
       - maps
   /map_exists:
@@ -708,10 +777,17 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/main.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/main.ErrorResponse'
+      security:
+      - BearerAuth: []
+      - ApiKeyAuth: []
       summary: Parse a replay file
       tags:
       - replay
@@ -738,11 +814,31 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/main.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/main.ErrorResponse'
+      security:
+      - BearerAuth: []
+      - ApiKeyAuth: []
       summary: Upload game stats
       tags:
       - stats
+securityDefinitions:
+  ApiKeyAuth:
+    description: API key supplied in the X-API-Key header. Alternative to the Authorization
+      header.
+    in: header
+    name: X-API-Key
+    type: apiKey
+  BearerAuth:
+    description: API key supplied as "Bearer <key>". Required on write endpoints when
+      CNC_AUTH_REQUIRED is true.
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/main.go
+++ b/main.go
@@ -43,6 +43,14 @@ type ErrorResponse struct {
 // @description Replay parser and stats API for Command & Conquer Generals / Zero Hour
 // @host localhost:8080
 // @BasePath /
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+// @description API key supplied as "Bearer <key>". Required on write endpoints when CNC_AUTH_REQUIRED is true.
+// @securityDefinitions.apikey ApiKeyAuth
+// @in header
+// @name X-API-Key
+// @description API key supplied in the X-API-Key header. Alternative to the Authorization header.
 func main() {
 	// Parse command line arguments
 	var (
@@ -313,6 +321,15 @@ func apiKeyAuth(keys apiKeyStore) gin.HandlerFunc {
 	}
 }
 
+// clientName returns the authenticated client name set by apiKeyAuth, or
+// "anonymous" when auth is disabled and no client was matched.
+func clientName(c *gin.Context) string {
+	if name := c.GetString("client"); name != "" {
+		return name
+	}
+	return "anonymous"
+}
+
 // extractAPIKey pulls the API key from the Authorization or X-API-Key header.
 func extractAPIKey(c *gin.Context) string {
 	if h := c.GetHeader("Authorization"); h != "" {
@@ -390,7 +407,10 @@ func startWebServer(objectStore *iniparse.ObjectStore, powerStore *iniparse.Powe
 // @Param file formData file true "Replay file to parse"
 // @Success 200 {object} zhreplay.EnhancedReplayV2
 // @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Security ApiKeyAuth
 // @Router /replay [post]
 func saveFileHandler(c *gin.Context, objectStore *iniparse.ObjectStore, powerStore *iniparse.PowerStore, upgradeStore *iniparse.UpgradeStore, colorStore *iniparse.ColorStore) {
 	file, err := c.FormFile("file")
@@ -422,6 +442,12 @@ func saveFileHandler(c *gin.Context, objectStore *iniparse.ObjectStore, powerSto
 
 	// If a stats file exists for this seed, return enhanced v2 replay
 	seed := replay.Header.Metadata.Seed
+
+	log.WithFields(log.Fields{
+		"seed":   seed,
+		"map":    replay.Header.Metadata.MapPath,
+		"client": clientName(c),
+	}).Info("Replay parsed")
 	if seed != "" && statsfile.Exists(seed) {
 		stats, err := statsfile.Load(seed)
 		if err != nil {
@@ -448,7 +474,10 @@ func saveFileHandler(c *gin.Context, objectStore *iniparse.ObjectStore, powerSto
 // @Param X-Game-Seed header string true "Game seed identifier"
 // @Success 200 {object} StatsUploadResponse
 // @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Security ApiKeyAuth
 // @Router /stats [post]
 func uploadStatsHandler(c *gin.Context) {
 	seed := c.GetHeader("X-Game-Seed")
@@ -483,7 +512,7 @@ func uploadStatsHandler(c *gin.Context) {
 		return
 	}
 
-	log.WithField("seed", seed).WithField("size", len(data)).Info("Stats file stored")
+	log.WithField("seed", seed).WithField("size", len(data)).WithField("client", clientName(c)).Info("Stats file stored")
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Stats stored successfully",
 		"seed":    seed,
@@ -532,7 +561,10 @@ func mapExistsHandler(c *gin.Context) {
 // @Param X-Game-Seed header string false "Game seed for telemetry correlation"
 // @Success 200 {object} map[string]any
 // @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Security ApiKeyAuth
 // @Router /add_map [post]
 func addMapHandler(c *gin.Context) {
 	crc := c.GetHeader("X-Map-CRC")
@@ -576,10 +608,11 @@ func addMapHandler(c *gin.Context) {
 	}
 
 	log.WithFields(log.Fields{
-		"crc":  crc,
-		"kind": kind,
-		"size": len(data),
-		"name": mapName,
+		"crc":    crc,
+		"kind":   kind,
+		"size":   len(data),
+		"name":   mapName,
+		"client": clientName(c),
 	}).Info("Map asset stored")
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Map asset stored successfully",


### PR DESCRIPTION
Protect the write endpoints (/replay, /stats, /add_map) with shared API keys while leaving the map read endpoints and docs open for game peers.

- CNC_API_KEYS holds comma-separated name:key pairs, so clients can be added, replaced, or removed without code changes. The matched client name is logged on each authenticated request.
- CNC_AUTH_REQUIRED toggles enforcement (defaults to true). When true with no valid keys, the server refuses to start.
- Multi-key matching uses constant-time compare with no early exit.
- Document the two schemes (Bearer / X-API-Key) in the Swagger and OpenAPI v3 specs; teach the converter to carry security blocks.
- Add a `make docs` target to regenerate the API docs.