### PR TITLE
Sync Zulu colors: shift Purple to indigo, add Violet

### DIFF
--- a/inizh/Data/INI/ZuluColors.ini
+++ b/inizh/Data/INI/ZuluColors.ini
@@ -24,15 +24,26 @@ MultiplayerColor ColorBrown
 End
 
 MultiplayerColor ColorMetallicGrey
-  TooltipName = Color:Metallic Grey
+  TooltipName = Color:MetallicGrey
   RGBColor = R:112 G:128 B:144
   RGBNightColor = R:112 G:128 B:144
 End
 
-MultiplayerColor ColorBlack
-  TooltipName = Color:Black
-  ; Engine treats RGB(0,0,0) as "no recolor" sentinel (W3DAssetManager.cpp),
-  ; so use near-black to trigger team color remapping.
-  RGBColor = R:1 G:1 B:1
-  RGBNightColor = R:1 G:1 B:1
+; --- Purple family rework -------------------------------------------------
+; Override the built-in Purple in place (block name token must equal the base
+; entry's TooltipName so the loader finds and overwrites it instead of
+; appending a duplicate). Shift it bluer/darker toward indigo to open room
+; for a second, redder violet below.
+MultiplayerColor Color:Purple
+  TooltipName = Color:Purple
+  RGBColor = R:90 G:0 B:200
+  RGBNightColor = R:80 G:0 B:180
+End
+
+; New redder violet, distinct from the now-indigo Purple above and from the
+; light Pink.
+MultiplayerColor ColorViolet
+  TooltipName = Color:Violet
+  RGBColor = R:190 G:0 B:160
+  RGBNightColor = R:175 G:0 B:140
 End

--- a/pkg/iniparse/iniparse.go
+++ b/pkg/iniparse/iniparse.go
@@ -430,6 +430,24 @@ func (c *ColorStore) loadColorFile(path string, required bool) error {
 	return c.parseFile(file)
 }
 
+// commitColor adds a parsed color to the store, replicating the engine's
+// override behavior (INI::parseMultiplayerColorDefinition): if the block's
+// name matches an existing color's TooltipName, overwrite that entry in place
+// rather than appending a duplicate. The original Name is preserved so the
+// color's reported identity and index are unchanged; only the swatch values
+// are updated. This is how the Zulu "Color:Purple" block re-tints the built-in
+// Purple without shifting later indices.
+func (c *ColorStore) commitColor(color *MultiplayerColor) {
+	for i := range c.Color {
+		if c.Color[i].TooltipName == color.Name {
+			c.Color[i].RGBColor = color.RGBColor
+			c.Color[i].RGBNightColor = color.RGBNightColor
+			return
+		}
+	}
+	c.Color = append(c.Color, *color)
+}
+
 func (c *ColorStore) parseFile(file io.Reader) error {
 	scanner := bufio.NewScanner(file)
 	var color *MultiplayerColor
@@ -438,7 +456,7 @@ func (c *ColorStore) parseFile(file io.Reader) error {
 		switch matchKey(line) {
 		case "MultiplayerColor":
 			if color != nil {
-				c.Color = append(c.Color, *color)
+				c.commitColor(color)
 			}
 			name, err := parseNameFromLine(line)
 			if err != nil {
@@ -479,7 +497,7 @@ func (c *ColorStore) parseFile(file io.Reader) error {
 		}
 	}
 	if color != nil {
-		c.Color = append(c.Color, *color)
+		c.commitColor(color)
 	}
 	return nil
 }


### PR DESCRIPTION
Mirror the game's committed ZuluColors.ini: re-tint the built-in Purple toward indigo and add a new redder Violet, drop the removed Black, and fix the MetallicGrey tooltip label.

Teach the color parser the engine's in-place override semantics: a MultiplayerColor block whose name matches an existing color's TooltipName overwrites that entry (preserving its Name) instead of appending. This keeps the Color:Purple re-tint at index 6 and Violet at 12, matching the engine's color list exactly so replay color IDs resolve correctly.