### PR TITLE
Add authenticated logs endpoints for per-match client logs

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -93,6 +93,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/get_logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a zip archive of every log file stored for the given match seed, with entries named \"\u003cplayer\u003e/\u003cfilename\u003e\". 404 if no logs are stored for that seed.",
+                "produces": [
+                    "application/zip"
+                ],
+                "tags": [
+                    "logs"
+                ],
+                "summary": "Download all match logs as a zip",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game seed identifying the match",
+                        "name": "seed",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Zip archive (application/zip)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/get_map": {
             "get": {
                 "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
@@ -223,6 +284,79 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logs": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names). Call once per player.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "logs"
+                ],
+                "summary": "Upload match log files for a player",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game seed identifying the match",
+                        "name": "X-Game-Seed",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Player identifier the logs belong to",
+                        "name": "X-Player",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "One or more log files",
+                        "name": "files",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -857,6 +991,16 @@ const docTemplate = `{
         "statsfile.TimeSeriesPlayer": {
             "type": "object",
             "properties": {
+                "incomeBySource": {
+                    "description": "IncomeBySource holds one cumulative-income series per source, keyed by\nthe same source names as Player.IncomeBySource. Present for stats JSON\nversion \u003e= 2; nil for older uploads.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "index": {
                     "type": "integer"
                 },
@@ -900,6 +1044,10 @@ const docTemplate = `{
                 },
                 "stats": {
                     "$ref": "#/definitions/zhreplay.EnrichedStats"
+                },
+                "statsVersion": {
+                    "description": "StatsVersion is the schema version of the stats JSON the game uploaded\n(the \"version\" field the exporter stamps), surfaced so consumers can see\nwhich stats format produced this replay. Omitted when no stats file was\navailable (basic replay-only responses).",
+                    "type": "integer"
                 },
                 "summary": {
                     "type": "array",
@@ -1119,6 +1267,12 @@ const docTemplate = `{
                 },
                 "faction": {
                     "type": "string"
+                },
+                "incomeBySource": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
                 },
                 "index": {
                     "type": "integer"

--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -474,6 +474,16 @@
       },
       "statsfile.TimeSeriesPlayer": {
         "properties": {
+          "incomeBySource": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "description": "IncomeBySource holds one cumulative-income series per source, keyed by\nthe same source names as Player.IncomeBySource. Present for stats JSON\nversion \u003e= 2; nil for older uploads.",
+            "type": "object"
+          },
           "index": {
             "type": "integer"
           },
@@ -517,6 +527,10 @@
           },
           "stats": {
             "$ref": "#/components/schemas/zhreplay.EnrichedStats"
+          },
+          "statsVersion": {
+            "description": "StatsVersion is the schema version of the stats JSON the game uploaded\n(the \"version\" field the exporter stamps), surfaced so consumers can see\nwhich stats format produced this replay. Omitted when no stats file was\navailable (basic replay-only responses).",
+            "type": "integer"
           },
           "summary": {
             "items": {
@@ -736,6 +750,12 @@
           },
           "faction": {
             "type": "string"
+          },
+          "incomeBySource": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object"
           },
           "index": {
             "type": "integer"
@@ -985,6 +1005,86 @@
         ]
       }
     },
+    "/get_logs": {
+      "get": {
+        "description": "Returns a zip archive of every log file stored for the given match seed, with entries named \"\u003cplayer\u003e/\u003cfilename\u003e\". 404 if no logs are stored for that seed.",
+        "parameters": [
+          {
+            "description": "Game seed identifying the match",
+            "in": "query",
+            "name": "seed",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "file"
+                }
+              }
+            },
+            "description": "Zip archive (application/zip)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Download all match logs as a zip",
+        "tags": [
+          "logs"
+        ]
+      }
+    },
     "/get_map": {
       "get": {
         "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
@@ -1158,6 +1258,106 @@
         "summary": "List stored asset kinds for a CRC",
         "tags": [
           "maps"
+        ]
+      }
+    },
+    "/logs": {
+      "post": {
+        "description": "Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names). Call once per player.",
+        "parameters": [
+          {
+            "description": "Game seed identifying the match",
+            "in": "header",
+            "name": "X-Game-Seed",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Player identifier the logs belong to",
+            "in": "header",
+            "name": "X-Player",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "files": {
+                    "description": "One or more log files",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "files"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Upload match log files for a player",
+        "tags": [
+          "logs"
         ]
       }
     },

--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -327,6 +327,13 @@ components:
       type: object
     statsfile.TimeSeriesPlayer:
       properties:
+        incomeBySource:
+          additionalProperties:
+            items:
+              type: integer
+            type: array
+          description: "IncomeBySource holds one cumulative-income series per source, keyed by\nthe same source names as Player.IncomeBySource. Present for stats JSON\nversion \u003e= 2; nil for older uploads."
+          type: object
         index:
           type: integer
         money:
@@ -356,6 +363,9 @@ components:
           type: integer
         stats:
           $ref: "#/components/schemas/zhreplay.EnrichedStats"
+        statsVersion:
+          description: "StatsVersion is the schema version of the stats JSON the game uploaded\n(the \"version\" field the exporter stamps), surfaced so consumers can see\nwhich stats format produced this replay. Omitted when no stats file was\navailable (basic replay-only responses)."
+          type: integer
         summary:
           items:
             $ref: "#/components/schemas/zhreplay.PlayerSummaryV2"
@@ -500,6 +510,10 @@ components:
           type: string
         faction:
           type: string
+        incomeBySource:
+          additionalProperties:
+            type: integer
+          type: object
         index:
           type: integer
         money:
@@ -663,6 +677,55 @@ paths:
       summary: Upload a map asset (.map / .tga / sidecar)
       tags:
         - maps
+  /get_logs:
+    get:
+      description: "Returns a zip archive of every log file stored for the given match seed, with entries named \"\u003cplayer\u003e/\u003cfilename\u003e\". 404 if no logs are stored for that seed."
+      parameters:
+        - description: Game seed identifying the match
+          in: query
+          name: seed
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: file
+          description: Zip archive (application/zip)
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Unauthorized
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Not Found
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Internal Server Error
+      security:
+        - BearerAuth:
+            []
+        - ApiKeyAuth:
+            []
+      summary: Download all match logs as a zip
+      tags:
+        - logs
   /get_map:
     get:
       description: "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory."
@@ -772,6 +835,69 @@ paths:
       summary: List stored asset kinds for a CRC
       tags:
         - maps
+  /logs:
+    post:
+      description: "Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names). Call once per player."
+      parameters:
+        - description: Game seed identifying the match
+          in: header
+          name: X-Game-Seed
+          required: true
+          schema:
+            type: string
+        - description: Player identifier the logs belong to
+          in: header
+          name: X-Player
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                files:
+                  description: One or more log files
+                  format: binary
+                  type: string
+              required:
+                - files
+              type: object
+        required: true
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+          description: OK
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Bad Request
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Unauthorized
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Internal Server Error
+      security:
+        - BearerAuth:
+            []
+        - ApiKeyAuth:
+            []
+      summary: Upload match log files for a player
+      tags:
+        - logs
   /map_exists:
     get:
       description: "Returns plain-text \"true\" if a .map file is already stored under MAPS_DIR for the given crc, \"false\" otherwise. Used by the Generals client right after a game ends to decide whether to upload its played map."

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -87,6 +87,67 @@
                 }
             }
         },
+        "/get_logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns a zip archive of every log file stored for the given match seed, with entries named \"\u003cplayer\u003e/\u003cfilename\u003e\". 404 if no logs are stored for that seed.",
+                "produces": [
+                    "application/zip"
+                ],
+                "tags": [
+                    "logs"
+                ],
+                "summary": "Download all match logs as a zip",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game seed identifying the match",
+                        "name": "seed",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Zip archive (application/zip)",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/get_map": {
             "get": {
                 "description": "Returns a zip archive whose entries are the .map file and (if available) the .tga preview, named after the original map basename. Suitable for direct extraction into a Generals Maps/ subdirectory.",
@@ -217,6 +278,79 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logs": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names). Call once per player.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "logs"
+                ],
+                "summary": "Upload match log files for a player",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game seed identifying the match",
+                        "name": "X-Game-Seed",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Player identifier the logs belong to",
+                        "name": "X-Player",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "One or more log files",
+                        "name": "files",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -851,6 +985,16 @@
         "statsfile.TimeSeriesPlayer": {
             "type": "object",
             "properties": {
+                "incomeBySource": {
+                    "description": "IncomeBySource holds one cumulative-income series per source, keyed by\nthe same source names as Player.IncomeBySource. Present for stats JSON\nversion \u003e= 2; nil for older uploads.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "index": {
                     "type": "integer"
                 },
@@ -894,6 +1038,10 @@
                 },
                 "stats": {
                     "$ref": "#/definitions/zhreplay.EnrichedStats"
+                },
+                "statsVersion": {
+                    "description": "StatsVersion is the schema version of the stats JSON the game uploaded\n(the \"version\" field the exporter stamps), surfaced so consumers can see\nwhich stats format produced this replay. Omitted when no stats file was\navailable (basic replay-only responses).",
+                    "type": "integer"
                 },
                 "summary": {
                     "type": "array",
@@ -1113,6 +1261,12 @@
                 },
                 "faction": {
                     "type": "string"
+                },
+                "incomeBySource": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
                 },
                 "index": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -325,6 +325,16 @@ definitions:
     type: object
   statsfile.TimeSeriesPlayer:
     properties:
+      incomeBySource:
+        additionalProperties:
+          items:
+            type: integer
+          type: array
+        description: |-
+          IncomeBySource holds one cumulative-income series per source, keyed by
+          the same source names as Player.IncomeBySource. Present for stats JSON
+          version >= 2; nil for older uploads.
+        type: object
       index:
         type: integer
       money:
@@ -354,6 +364,13 @@ definitions:
         type: integer
       stats:
         $ref: '#/definitions/zhreplay.EnrichedStats'
+      statsVersion:
+        description: |-
+          StatsVersion is the schema version of the stats JSON the game uploaded
+          (the "version" field the exporter stamps), surfaced so consumers can see
+          which stats format produced this replay. Omitted when no stats file was
+          available (basic replay-only responses).
+        type: integer
       summary:
         items:
           $ref: '#/definitions/zhreplay.PlayerSummaryV2'
@@ -498,6 +515,10 @@ definitions:
         type: string
       faction:
         type: string
+      incomeBySource:
+        additionalProperties:
+          type: integer
+        type: object
       index:
         type: integer
       money:
@@ -634,6 +655,46 @@ paths:
       summary: Upload a map asset (.map / .tga / sidecar)
       tags:
       - maps
+  /get_logs:
+    get:
+      description: Returns a zip archive of every log file stored for the given match
+        seed, with entries named "<player>/<filename>". 404 if no logs are stored
+        for that seed.
+      parameters:
+      - description: Game seed identifying the match
+        in: query
+        name: seed
+        required: true
+        type: string
+      produces:
+      - application/zip
+      responses:
+        "200":
+          description: Zip archive (application/zip)
+          schema:
+            type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      security:
+      - BearerAuth: []
+      - ApiKeyAuth: []
+      summary: Download all match logs as a zip
+      tags:
+      - logs
   /get_map:
     get:
       description: Returns a zip archive whose entries are the .map file and (if available)
@@ -729,6 +790,55 @@ paths:
       summary: List stored asset kinds for a CRC
       tags:
       - maps
+  /logs:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Store one or more client log files for a match, keyed by game seed
+        and grouped by player. Send a multipart/form-data body with one or more file
+        parts (any field names). Call once per player.
+      parameters:
+      - description: Game seed identifying the match
+        in: header
+        name: X-Game-Seed
+        required: true
+        type: string
+      - description: Player identifier the logs belong to
+        in: header
+        name: X-Player
+        required: true
+        type: string
+      - description: One or more log files
+        in: formData
+        name: files
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      security:
+      - BearerAuth: []
+      - ApiKeyAuth: []
+      summary: Upload match log files for a player
+      tags:
+      - logs
   /map_exists:
     get:
       description: Returns plain-text "true" if a .map file is already stored under

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 	_ "github.com/bill-rich/cncstats/docs"
 	"github.com/bill-rich/cncstats/pkg/bitparse"
 	"github.com/bill-rich/cncstats/pkg/iniparse"
+	"github.com/bill-rich/cncstats/pkg/logfile"
 	"github.com/bill-rich/cncstats/pkg/mapfile"
 	"github.com/bill-rich/cncstats/pkg/statsfile"
 	"github.com/bill-rich/cncstats/pkg/zhreplay"
@@ -364,7 +366,7 @@ func startWebServer(objectStore *iniparse.ObjectStore, powerStore *iniparse.Powe
 	// endpoints (map files, zips) are excluded to avoid wasting CPU
 	// recompressing them.
 	router.Use(gzip.Gzip(gzip.DefaultCompression,
-		gzip.WithExcludedPaths([]string{"/get_map_file", "/get_map", "/zip"})))
+		gzip.WithExcludedPaths([]string{"/get_map_file", "/get_map", "/get_logs", "/zip"})))
 
 	// Write endpoints are grouped behind a shared API key. Read endpoints
 	// (map downloads, docs) stay open because game peers need them mid-lobby
@@ -396,6 +398,11 @@ func startWebServer(objectStore *iniparse.ObjectStore, powerStore *iniparse.Powe
 	writes.POST("/stats", func(c *gin.Context) {
 		uploadStatsHandler(c)
 	})
+
+	// Logs endpoints - clients post their per-match log files, retrieved as a zip by seed.
+	// Both are authenticated: logs may contain sensitive client detail and aren't needed mid-lobby.
+	writes.POST("/logs", uploadLogsHandler)
+	writes.GET("/get_logs", getLogsHandler)
 
 	// Map endpoints
 	router.GET("/map_exists", mapExistsHandler)
@@ -546,6 +553,188 @@ func uploadStatsHandler(c *gin.Context) {
 		"seed":    seed,
 		"size":    len(data),
 	})
+}
+
+// uploadLogsHandler stores one or more log files for a match. The client
+// sends a multipart form containing that player's log file(s); the match
+// is identified by X-Game-Seed and the player by X-Player. Each form file
+// is stored under <seed>/<player>/<original filename>. Call once per
+// player (each call may carry multiple files).
+// @Summary Upload match log files for a player
+// @Description Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names). Call once per player.
+// @Tags logs
+// @Accept multipart/form-data
+// @Produce json
+// @Param X-Game-Seed header string true "Game seed identifying the match"
+// @Param X-Player header string true "Player identifier the logs belong to"
+// @Param files formData file true "One or more log files"
+// @Success 200 {object} map[string]any
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Security ApiKeyAuth
+// @Router /logs [post]
+func uploadLogsHandler(c *gin.Context) {
+	seed := c.GetHeader("X-Game-Seed")
+	if seed == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "X-Game-Seed header is required",
+		})
+		return
+	}
+	player := c.GetHeader("X-Player")
+	if player == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "X-Player header is required",
+		})
+		return
+	}
+
+	form, err := c.MultipartForm()
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error":   "Could not parse multipart form",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	// Gather every file part regardless of field name so clients can use
+	// whatever names are convenient.
+	var files []*multipart.FileHeader
+	for _, fhs := range form.File {
+		files = append(files, fhs...)
+	}
+	if len(files) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "No log files received",
+		})
+		return
+	}
+
+	stored := make([]string, 0, len(files))
+	var total int
+	for _, fh := range files {
+		fileIn, err := fh.Open()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "Could not open uploaded file",
+				"details": err.Error(),
+			})
+			return
+		}
+		data, err := io.ReadAll(fileIn)
+		fileIn.Close()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "Failed to read uploaded file",
+				"details": err.Error(),
+			})
+			return
+		}
+		if err := logfile.Store(seed, player, fh.Filename, data); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error":   "Failed to store log file",
+				"details": err.Error(),
+			})
+			return
+		}
+		stored = append(stored, fh.Filename)
+		total += len(data)
+	}
+
+	log.WithFields(log.Fields{
+		"seed":   seed,
+		"player": player,
+		"files":  len(stored),
+		"size":   total,
+		"client": clientName(c),
+	}).Info("Log files stored")
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Logs stored successfully",
+		"seed":    seed,
+		"player":  player,
+		"files":   stored,
+		"size":    total,
+	})
+}
+
+// getLogsHandler returns a zip archive of every stored log file for a
+// match. Entries inside the zip are named "<player>/<filename>" so the
+// per-player grouping is preserved on extraction.
+// @Summary Download all match logs as a zip
+// @Description Returns a zip archive of every log file stored for the given match seed, with entries named "<player>/<filename>". 404 if no logs are stored for that seed.
+// @Tags logs
+// @Produce application/zip
+// @Param seed query string true "Game seed identifying the match"
+// @Success 200 {file} file "Zip archive (application/zip)"
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Security ApiKeyAuth
+// @Router /get_logs [get]
+func getLogsHandler(c *gin.Context) {
+	seed := c.Query("seed")
+	if seed == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "seed query parameter is required",
+		})
+		return
+	}
+
+	files, err := logfile.List(seed)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to list logs",
+			"details": err.Error(),
+		})
+		return
+	}
+	if len(files) == 0 {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+			"error": "no logs stored for that seed",
+			"seed":  seed,
+		})
+		return
+	}
+
+	// Log files are text and modest in size; build the zip in memory.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	var zipErr error
+	for _, f := range files {
+		data, err := logfile.Load(seed, f.Player, f.Name)
+		if err != nil {
+			// List said it's there; if Load disagrees, race with a
+			// concurrent delete. Skip rather than abort.
+			continue
+		}
+		entry, err := zw.Create(f.Player + "/" + f.Name)
+		if err != nil {
+			zipErr = err
+			break
+		}
+		if _, err := entry.Write(data); err != nil {
+			zipErr = err
+			break
+		}
+	}
+	if zipErr == nil {
+		zipErr = zw.Close()
+	}
+	if zipErr != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to build zip archive",
+			"details": zipErr.Error(),
+		})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", seed+"-logs.zip"))
+	c.Data(http.StatusOK, "application/zip", buf.Bytes())
 }
 
 // mapExistsHandler reports whether the server already has a map for the

--- a/pkg/logfile/logfile.go
+++ b/pkg/logfile/logfile.go
@@ -1,0 +1,163 @@
+// Package logfile persists per-match client log files, keyed by the game
+// seed (the same identifier used by pkg/statsfile), grouped by the player
+// that produced them. It mirrors the on-disk pattern used by pkg/mapfile.
+//
+// Layout under LogsDir:
+//
+//	<seed>/
+//	  <player>/
+//	    <filename>      # one uploaded log file, original basename preserved
+//	    ...
+//	  <player>/
+//	    ...
+//
+// A match "exists" once its seed directory has been created by at least
+// one successful upload.
+package logfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LogsDir is the directory where log files are stored.
+// Set via LOGS_DIR env var or defaults to ./logs/
+var LogsDir = "./logs"
+
+func init() {
+	if dir := os.Getenv("LOGS_DIR"); dir != "" {
+		LogsDir = dir
+	}
+}
+
+// LogFile describes one stored log file for a match.
+type LogFile struct {
+	Player string `json:"player"`
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+}
+
+// MatchDir returns the per-seed storage directory for a match.
+func MatchDir(seed string) string {
+	return filepath.Join(LogsDir, seed)
+}
+
+// sanitizeComponent reduces an untrusted path component (player id or
+// filename) to a safe single-segment name, guarding against path
+// traversal. Returns an error if nothing usable remains.
+func sanitizeComponent(raw string) (string, error) {
+	// The game runs on Windows and may send backslash separators; treat
+	// both separators as directory boundaries before taking the basename.
+	cleaned := strings.ReplaceAll(raw, "\\", "/")
+	base := filepath.Base(cleaned)
+	base = strings.TrimSpace(base)
+	if base == "" || base == "." || base == ".." {
+		return "", fmt.Errorf("logfile: invalid path component %q", raw)
+	}
+	return base, nil
+}
+
+// Store writes one uploaded log file under <seed>/<player>/<filename>.
+// player and filename are sanitized to their basenames; a repeated
+// (seed, player, filename) overwrites silently.
+func Store(seed, player, filename string, data []byte) error {
+	if seed == "" {
+		return errors.New("logfile.Store: empty seed")
+	}
+	safePlayer, err := sanitizeComponent(player)
+	if err != nil {
+		return err
+	}
+	safeName, err := sanitizeComponent(filename)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Join(MatchDir(seed), safePlayer)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeName), data, 0644); err != nil {
+		return fmt.Errorf("write log file: %w", err)
+	}
+	return nil
+}
+
+// Exists reports whether any logs have been stored for the given seed.
+func Exists(seed string) bool {
+	if seed == "" {
+		return false
+	}
+	info, err := os.Stat(MatchDir(seed))
+	return err == nil && info.IsDir()
+}
+
+// List returns every stored log file for a match, sorted by player then
+// filename. Returns an empty slice if the match has no logs.
+func List(seed string) ([]LogFile, error) {
+	if seed == "" {
+		return nil, errors.New("logfile.List: empty seed")
+	}
+	matchDir := MatchDir(seed)
+	players, err := os.ReadDir(matchDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []LogFile{}, nil
+		}
+		return nil, fmt.Errorf("read match dir: %w", err)
+	}
+
+	out := []LogFile{}
+	for _, p := range players {
+		if !p.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(matchDir, p.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read player dir: %w", err)
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			info, err := f.Info()
+			if err != nil {
+				return nil, fmt.Errorf("stat log file: %w", err)
+			}
+			out = append(out, LogFile{
+				Player: p.Name(),
+				Name:   f.Name(),
+				Size:   info.Size(),
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Player != out[j].Player {
+			return out[i].Player < out[j].Player
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// Load returns the raw bytes of one stored log file. Returns
+// os.ErrNotExist if the file isn't stored.
+func Load(seed, player, filename string) ([]byte, error) {
+	if seed == "" {
+		return nil, errors.New("logfile.Load: empty seed")
+	}
+	safePlayer, err := sanitizeComponent(player)
+	if err != nil {
+		return nil, err
+	}
+	safeName, err := sanitizeComponent(filename)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(filepath.Join(MatchDir(seed), safePlayer, safeName))
+}


### PR DESCRIPTION
Add POST /logs and GET /get_logs, keyed by game seed and grouped by player. Clients bulk-upload a player's log files via multipart form (X-Game-Seed + X-Player headers); logs are stored under <seed>/<player>/<filename> and retrieved as a zip of the whole match.

Both endpoints require an API key. Path components from headers and filenames are sanitized to basenames to prevent traversal. Regenerated Swagger 2.0 and OpenAPI v3 docs.