### PR TITLE
Parse hunted events from version 3 stats files

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -473,7 +473,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.",
+                "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed. If a stats file already exists for the seed and the uploaded file is smaller, the upload is rejected with 409 unless force is set.",
                 "consumes": [
                     "application/octet-stream"
                 ],
@@ -491,6 +491,12 @@ const docTemplate = `{
                         "name": "X-Game-Seed",
                         "in": "header",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Overwrite an existing stats file even if the upload is smaller (can also be set via the X-Force header)",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -508,6 +514,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -927,6 +939,20 @@ const docTemplate = `{
                 }
             }
         },
+        "statsfile.HuntedEvent": {
+            "type": "object",
+            "properties": {
+                "frame": {
+                    "type": "integer"
+                },
+                "hunted": {
+                    "type": "boolean"
+                },
+                "player": {
+                    "type": "integer"
+                }
+            }
+        },
         "statsfile.RadarEvent": {
             "type": "object",
             "properties": {
@@ -1201,6 +1227,12 @@ const docTemplate = `{
                         "$ref": "#/definitions/statsfile.EnergyEvent"
                     }
                 },
+                "huntedEvents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/statsfile.HuntedEvent"
+                    }
+                },
                 "killEvents": {
                     "type": "array",
                     "items": {
@@ -1274,6 +1306,13 @@ const docTemplate = `{
                 "faction": {
                     "type": "string"
                 },
+                "hunted": {
+                    "type": "boolean"
+                },
+                "huntedFrame": {
+                    "description": "HuntedFrame is the frame this player first became hunted (lost all\nability to rebuild: no dozers/workers and no structure that can produce\none). UnhuntedFrame is the first frame they recovered from that state\n(e.g. captured an enemy command center or hijacked a dozer). Hunted is\ntheir final state. Zero frames mean \"never\"; requires stats version \u003e= 3.",
+                    "type": "integer"
+                },
                 "incomeBySource": {
                     "type": "object",
                     "additionalProperties": {
@@ -1311,6 +1350,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "team": {
+                    "type": "integer"
+                },
+                "unhuntedFrame": {
                     "type": "integer"
                 },
                 "unitsCreated": {

--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -405,6 +405,20 @@
         },
         "type": "object"
       },
+      "statsfile.HuntedEvent": {
+        "properties": {
+          "frame": {
+            "type": "integer"
+          },
+          "hunted": {
+            "type": "boolean"
+          },
+          "player": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "statsfile.RadarEvent": {
         "properties": {
           "frame": {
@@ -678,6 +692,12 @@
             },
             "type": "array"
           },
+          "huntedEvents": {
+            "items": {
+              "$ref": "#/components/schemas/statsfile.HuntedEvent"
+            },
+            "type": "array"
+          },
           "killEvents": {
             "items": {
               "$ref": "#/components/schemas/zhreplay.EnrichedKillEvent"
@@ -751,6 +771,13 @@
           "faction": {
             "type": "string"
           },
+          "hunted": {
+            "type": "boolean"
+          },
+          "huntedFrame": {
+            "description": "HuntedFrame is the frame this player first became hunted (lost all\nability to rebuild: no dozers/workers and no structure that can produce\none). UnhuntedFrame is the first frame they recovered from that state\n(e.g. captured an enemy command center or hijacked a dozer). Hunted is\ntheir final state. Zero frames mean \"never\"; requires stats version \u003e= 3.",
+            "type": "integer"
+          },
           "incomeBySource": {
             "additionalProperties": {
               "type": "integer"
@@ -788,6 +815,9 @@
             "type": "string"
           },
           "team": {
+            "type": "integer"
+          },
+          "unhuntedFrame": {
             "type": "integer"
           },
           "unitsCreated": {
@@ -1494,7 +1524,7 @@
     },
     "/stats": {
       "post": {
-        "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.",
+        "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed. If a stats file already exists for the seed and the uploaded file is smaller, the upload is rejected with 409 unless force is set.",
         "parameters": [
           {
             "description": "Game seed identifier",
@@ -1503,6 +1533,14 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Overwrite an existing stats file even if the upload is smaller (can also be set via the X-Force header)",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -1547,6 +1585,16 @@
               }
             },
             "description": "Unauthorized"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/main.ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
           },
           "500": {
             "content": {

--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -282,6 +282,15 @@ components:
         production:
           type: integer
       type: object
+    statsfile.HuntedEvent:
+      properties:
+        frame:
+          type: integer
+        hunted:
+          type: boolean
+        player:
+          type: integer
+      type: object
     statsfile.RadarEvent:
       properties:
         frame:
@@ -462,6 +471,10 @@ components:
           items:
             $ref: "#/components/schemas/statsfile.EnergyEvent"
           type: array
+        huntedEvents:
+          items:
+            $ref: "#/components/schemas/statsfile.HuntedEvent"
+          type: array
         killEvents:
           items:
             $ref: "#/components/schemas/zhreplay.EnrichedKillEvent"
@@ -510,6 +523,11 @@ components:
           type: string
         faction:
           type: string
+        hunted:
+          type: boolean
+        huntedFrame:
+          description: "HuntedFrame is the frame this player first became hunted (lost all\nability to rebuild: no dozers/workers and no structure that can produce\none). UnhuntedFrame is the first frame they recovered from that state\n(e.g. captured an enemy command center or hijacked a dozer). Hunted is\ntheir final state. Zero frames mean \"never\"; requires stats version \u003e= 3."
+          type: integer
         incomeBySource:
           additionalProperties:
             type: integer
@@ -535,6 +553,8 @@ components:
         side:
           type: string
         team:
+          type: integer
+        unhuntedFrame:
           type: integer
         unitsCreated:
           additionalProperties:
@@ -981,7 +1001,7 @@ paths:
         - replay
   /stats:
     post:
-      description: Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.
+      description: "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed. If a stats file already exists for the seed and the uploaded file is smaller, the upload is rejected with 409 unless force is set."
       parameters:
         - description: Game seed identifier
           in: header
@@ -989,6 +1009,11 @@ paths:
           required: true
           schema:
             type: string
+        - description: Overwrite an existing stats file even if the upload is smaller (can also be set via the X-Force header)
+          in: query
+          name: force
+          schema:
+            type: boolean
       requestBody:
         content:
           application/octet-stream:
@@ -1015,6 +1040,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/main.ErrorResponse"
           description: Unauthorized
+        409:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/main.ErrorResponse"
+          description: Conflict
         500:
           content:
             application/json:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -467,7 +467,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed.",
+                "description": "Receive gzip-compressed JSON stats from a Generals game and store them keyed by seed. If a stats file already exists for the seed and the uploaded file is smaller, the upload is rejected with 409 unless force is set.",
                 "consumes": [
                     "application/octet-stream"
                 ],
@@ -485,6 +485,12 @@
                         "name": "X-Game-Seed",
                         "in": "header",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Overwrite an existing stats file even if the upload is smaller (can also be set via the X-Force header)",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -502,6 +508,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/main.ErrorResponse"
                         }
@@ -921,6 +933,20 @@
                 }
             }
         },
+        "statsfile.HuntedEvent": {
+            "type": "object",
+            "properties": {
+                "frame": {
+                    "type": "integer"
+                },
+                "hunted": {
+                    "type": "boolean"
+                },
+                "player": {
+                    "type": "integer"
+                }
+            }
+        },
         "statsfile.RadarEvent": {
             "type": "object",
             "properties": {
@@ -1195,6 +1221,12 @@
                         "$ref": "#/definitions/statsfile.EnergyEvent"
                     }
                 },
+                "huntedEvents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/statsfile.HuntedEvent"
+                    }
+                },
                 "killEvents": {
                     "type": "array",
                     "items": {
@@ -1268,6 +1300,13 @@
                 "faction": {
                     "type": "string"
                 },
+                "hunted": {
+                    "type": "boolean"
+                },
+                "huntedFrame": {
+                    "description": "HuntedFrame is the frame this player first became hunted (lost all\nability to rebuild: no dozers/workers and no structure that can produce\none). UnhuntedFrame is the first frame they recovered from that state\n(e.g. captured an enemy command center or hijacked a dozer). Hunted is\ntheir final state. Zero frames mean \"never\"; requires stats version \u003e= 3.",
+                    "type": "integer"
+                },
                 "incomeBySource": {
                     "type": "object",
                     "additionalProperties": {
@@ -1305,6 +1344,9 @@
                     "type": "string"
                 },
                 "team": {
+                    "type": "integer"
+                },
+                "unhuntedFrame": {
                     "type": "integer"
                 },
                 "unitsCreated": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -280,6 +280,15 @@ definitions:
       production:
         type: integer
     type: object
+  statsfile.HuntedEvent:
+    properties:
+      frame:
+        type: integer
+      hunted:
+        type: boolean
+      player:
+        type: integer
+    type: object
   statsfile.RadarEvent:
     properties:
       frame:
@@ -467,6 +476,10 @@ definitions:
         items:
           $ref: '#/definitions/statsfile.EnergyEvent'
         type: array
+      huntedEvents:
+        items:
+          $ref: '#/definitions/statsfile.HuntedEvent'
+        type: array
       killEvents:
         items:
           $ref: '#/definitions/zhreplay.EnrichedKillEvent'
@@ -515,6 +528,16 @@ definitions:
         type: string
       faction:
         type: string
+      hunted:
+        type: boolean
+      huntedFrame:
+        description: |-
+          HuntedFrame is the frame this player first became hunted (lost all
+          ability to rebuild: no dozers/workers and no structure that can produce
+          one). UnhuntedFrame is the first frame they recovered from that state
+          (e.g. captured an enemy command center or hijacked a dozer). Hunted is
+          their final state. Zero frames mean "never"; requires stats version >= 3.
+        type: integer
       incomeBySource:
         additionalProperties:
           type: integer
@@ -540,6 +563,8 @@ definitions:
       side:
         type: string
       team:
+        type: integer
+      unhuntedFrame:
         type: integer
       unitsCreated:
         additionalProperties:
@@ -911,13 +936,19 @@ paths:
       consumes:
       - application/octet-stream
       description: Receive gzip-compressed JSON stats from a Generals game and store
-        them keyed by seed.
+        them keyed by seed. If a stats file already exists for the seed and the uploaded
+        file is smaller, the upload is rejected with 409 unless force is set.
       parameters:
       - description: Game seed identifier
         in: header
         name: X-Game-Seed
         required: true
         type: string
+      - description: Overwrite an existing stats file even if the upload is smaller
+          (can also be set via the X-Force header)
+        in: query
+        name: force
+        type: boolean
       produces:
       - application/json
       responses:
@@ -931,6 +962,10 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/main.ErrorResponse'
         "500":

--- a/pkg/statsfile/statsfile.go
+++ b/pkg/statsfile/statsfile.go
@@ -24,6 +24,7 @@ type GameStats struct {
 	SciencePointsEvents []SciencePointsEvent `json:"sciencePointsEvents"`
 	RadarEvents         []RadarEvent         `json:"radarEvents"`
 	DeathEvents         []DeathEvent         `json:"deathEvents"`
+	HuntedEvents        []HuntedEvent        `json:"huntedEvents"`
 	BattlePlanEvents    []BattlePlanEvent    `json:"battlePlanEvents"`
 	TimeSeries          TimeSeries           `json:"timeSeries"`
 }
@@ -143,6 +144,18 @@ type RadarEvent struct {
 type DeathEvent struct {
 	Frame  uint `json:"frame"`
 	Player int  `json:"player"`
+}
+
+// HuntedEvent marks a player transitioning into or out of the hunted state:
+// hunted means they can no longer rebuild (no dozer or worker alive and no
+// structure that can produce one, i.e. command center or GLA supply stash).
+// Becoming un-hunted is rare and means they regained a builder, e.g. by
+// capturing an enemy command center or hijacking a dozer. Present for stats
+// JSON version >= 3; nil for older uploads.
+type HuntedEvent struct {
+	Frame  uint `json:"frame"`
+	Player int  `json:"player"`
+	Hunted bool `json:"hunted"`
 }
 
 type BattlePlanEvent struct {

--- a/pkg/zhreplay/enhanced_replay_v2.go
+++ b/pkg/zhreplay/enhanced_replay_v2.go
@@ -109,6 +109,14 @@ type PlayerSummaryV2 struct {
 	MoneyEarned    int                              `json:"moneyEarned"`
 	MoneySpent     int                              `json:"moneySpent"`
 	IncomeBySource map[string]int                   `json:"incomeBySource,omitempty"`
+	// HuntedFrame is the frame this player first became hunted (lost all
+	// ability to rebuild: no dozers/workers and no structure that can produce
+	// one). UnhuntedFrame is the first frame they recovered from that state
+	// (e.g. captured an enemy command center or hijacked a dozer). Hunted is
+	// their final state. Zero frames mean "never"; requires stats version >= 3.
+	HuntedFrame   uint                              `json:"huntedFrame,omitempty"`
+	UnhuntedFrame uint                              `json:"unhuntedFrame,omitempty"`
+	Hunted        bool                              `json:"hunted,omitempty"`
 	Score          int                              `json:"score"`
 	Academy        *statsfile.Academy               `json:"academy,omitempty"`
 	UnitsCreated   map[string]*object.ObjectSummary `json:"unitsCreated"`
@@ -148,6 +156,7 @@ type EnrichedStats struct {
 	SciencePointsEvents []statsfile.SciencePointsEvent `json:"sciencePointsEvents"`
 	RadarEvents         []statsfile.RadarEvent         `json:"radarEvents"`
 	DeathEvents         []statsfile.DeathEvent         `json:"deathEvents"`
+	HuntedEvents        []statsfile.HuntedEvent        `json:"huntedEvents"`
 	BattlePlanEvents    []statsfile.BattlePlanEvent    `json:"battlePlanEvents"`
 	TimeSeries          statsfile.TimeSeries           `json:"timeSeries"`
 }
@@ -173,6 +182,7 @@ func enrichStats(stats *statsfile.GameStats, objectStore *iniparse.ObjectStore) 
 		SciencePointsEvents: stats.SciencePointsEvents,
 		RadarEvents:         stats.RadarEvents,
 		DeathEvents:         stats.DeathEvents,
+		HuntedEvents:        stats.HuntedEvents,
 		BattlePlanEvents:    stats.BattlePlanEvents,
 		TimeSeries:          stats.TimeSeries,
 	}
@@ -273,6 +283,23 @@ func ConvertToEnhancedReplayV2(replay *Replay, stats *statsfile.GameStats, objec
 		p.IncomeBySource = sp.IncomeBySource
 		p.Score = sp.Score
 		p.Academy = sp.Academy
+	}
+
+	// Fold hunted transition events into per-player summary fields.
+	for _, he := range stats.HuntedEvents {
+		idx := he.Player - 1
+		if idx < 0 || idx >= len(nonObservers) {
+			continue
+		}
+		p := nonObservers[idx]
+		if he.Hunted {
+			if p.HuntedFrame == 0 {
+				p.HuntedFrame = he.Frame
+			}
+		} else if p.HuntedFrame != 0 && p.UnhuntedFrame == 0 {
+			p.UnhuntedFrame = he.Frame
+		}
+		p.Hunted = he.Hunted
 	}
 
 	// Determine winners using death events from stats

--- a/pkg/zhreplay/hunted_test.go
+++ b/pkg/zhreplay/hunted_test.go
@@ -1,0 +1,121 @@
+package zhreplay
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bill-rich/cncstats/pkg/statsfile"
+	"github.com/bill-rich/cncstats/pkg/zhreplay/header"
+	"github.com/bill-rich/cncstats/pkg/zhreplay/object"
+)
+
+// Mirrors the shape StatsExporter.cpp emits for version 3 stats JSON.
+const huntedStatsJSON = `{
+"version":3,
+"game":{"map":"maps/test","mode":"LAN","frameCount":30000,"seed":42,"replayFile":"test.rep","playerCount":2,"snapshotInterval":30},
+"players":[
+{"index":1,"displayName":"Alice","side":"America","type":"Human","color":"#FF0000","money":100,"moneyEarned":5000,"moneySpent":4000,"score":10},
+{"index":2,"displayName":"Bob","side":"GLA","type":"Human","color":"#00FF00","money":200,"moneyEarned":6000,"moneySpent":5000,"score":20}
+],
+"buildEvents":[],
+"killEvents":[],
+"captureEvents":[],
+"energyEvents":[],
+"rankEvents":[],
+"skillPointsEvents":[],
+"sciencePointsEvents":[],
+"radarEvents":[],
+"deathEvents":[],
+"huntedEvents":[
+{"frame":9000,"player":2,"hunted":true},
+{"frame":9600,"player":2,"hunted":false},
+{"frame":21000,"player":2,"hunted":true}
+],
+"battlePlanEvents":[],
+"timeSeries":{"players":[]}
+}`
+
+func huntedTestStats(t *testing.T) *statsfile.GameStats {
+	t.Helper()
+	var stats statsfile.GameStats
+	if err := json.Unmarshal([]byte(huntedStatsJSON), &stats); err != nil {
+		t.Fatalf("unmarshal stats JSON: %v", err)
+	}
+	return &stats
+}
+
+func TestHuntedEventsParse(t *testing.T) {
+	stats := huntedTestStats(t)
+
+	if len(stats.HuntedEvents) != 3 {
+		t.Fatalf("expected 3 hunted events, got %d", len(stats.HuntedEvents))
+	}
+	first := stats.HuntedEvents[0]
+	if first.Frame != 9000 || first.Player != 2 || !first.Hunted {
+		t.Errorf("unexpected first hunted event: %+v", first)
+	}
+	second := stats.HuntedEvents[1]
+	if second.Frame != 9600 || second.Player != 2 || second.Hunted {
+		t.Errorf("unexpected second hunted event: %+v", second)
+	}
+}
+
+func TestHuntedSummaryFold(t *testing.T) {
+	stats := huntedTestStats(t)
+
+	replay := &Replay{
+		Header: &header.GeneralsHeader{},
+		Summary: []*object.PlayerSummary{
+			{Name: "Alice", Side: "USA", Team: 1},
+			{Name: "Bob", Side: "GLA", Team: 2},
+		},
+	}
+
+	v2 := ConvertToEnhancedReplayV2(replay, stats, nil)
+
+	if v2.Stats == nil || len(v2.Stats.HuntedEvents) != 3 {
+		t.Fatalf("hunted events not passed through to enriched stats: %+v", v2.Stats)
+	}
+
+	alice := v2.Summary[0]
+	if alice.HuntedFrame != 0 || alice.UnhuntedFrame != 0 || alice.Hunted {
+		t.Errorf("Alice should have no hunted state, got frame=%d unhunted=%d hunted=%v",
+			alice.HuntedFrame, alice.UnhuntedFrame, alice.Hunted)
+	}
+
+	bob := v2.Summary[1]
+	if bob.HuntedFrame != 9000 {
+		t.Errorf("Bob HuntedFrame = %d, want 9000 (first hunted event)", bob.HuntedFrame)
+	}
+	if bob.UnhuntedFrame != 9600 {
+		t.Errorf("Bob UnhuntedFrame = %d, want 9600 (first recovery)", bob.UnhuntedFrame)
+	}
+	if !bob.Hunted {
+		t.Errorf("Bob final Hunted = false, want true (last event was hunted)")
+	}
+}
+
+func TestHuntedSummaryJSONOmitsWhenNever(t *testing.T) {
+	stats := huntedTestStats(t)
+	stats.HuntedEvents = nil
+
+	replay := &Replay{
+		Header: &header.GeneralsHeader{},
+		Summary: []*object.PlayerSummary{
+			{Name: "Alice", Side: "USA", Team: 1},
+			{Name: "Bob", Side: "GLA", Team: 2},
+		},
+	}
+
+	v2 := ConvertToEnhancedReplayV2(replay, stats, nil)
+	out, err := json.Marshal(v2.Summary[0])
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	for _, key := range []string{"huntedFrame", "unhuntedFrame", `"hunted"`} {
+		if strings.Contains(string(out), key) {
+			t.Errorf("summary JSON should omit %s when never hunted: %s", key, out)
+		}
+	}
+}


### PR DESCRIPTION
Companion to GeneralsZulu/LegacyGameClient#102. The game's stats exporter now emits a `huntedEvents` array of `{frame, player, hunted}` transitions when a player loses all ability to rebuild (no dozers or workers alive and no structure that can produce one: command center or GLA supply stash), or recovers from that state by capturing an enemy structure or hijacking a dozer.

- `pkg/statsfile`: new `HuntedEvent` type and `GameStats.HuntedEvents`, so the field survives unmarshal instead of being silently dropped.
- `pkg/zhreplay`: events pass through to the enhanced replay v2 `stats.huntedEvents`, and each player summary gains `huntedFrame` (first time hunted), `unhuntedFrame` (first recovery), and `hunted` (final state), all omitted for players never hunted.
- Tests covering parse, summary fold, and omit behavior; API docs regenerated with `make docs`.

Old (version < 3) stats files simply have no hunted data, so the new fields stay omitted.