### PR TITLE
Keep the coordinator's log after the container is recreated

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bill-rich/cncstats/pkg/iniparse"
 	"github.com/bill-rich/cncstats/pkg/logfile"
 	"github.com/bill-rich/cncstats/pkg/mapfile"
+	"github.com/bill-rich/cncstats/pkg/serverlog"
 	"github.com/bill-rich/cncstats/pkg/statsfile"
 	"github.com/bill-rich/cncstats/pkg/zhreplay"
 	"github.com/gin-contrib/gzip"
@@ -93,6 +94,14 @@ func main() {
 		log.SetLevel(log.InfoLevel) // Ensure InfoLevel is set explicitly
 	}
 
+	// Tee the log stream to a file on the logs volume. Container stderr is
+	// discarded when the container is recreated, which is exactly when we
+	// lose the coordinator's record of a player's failed host/join attempt.
+	// Best-effort: if the file can't be opened we keep running on stderr.
+	if logSink := startFileLogging(); logSink != nil {
+		defer logSink.Close()
+	}
+
 	log.Info("CNC Stats application starting...")
 
 	// Handle local mode
@@ -155,6 +164,43 @@ func main() {
 }
 
 // Helper functions
+
+// startFileLogging tees logrus onto a persistent per-day file in addition to
+// stderr, so the log survives container recreation. The default location is
+// a "server" subdirectory of the logs volume (LOGS_DIR), which is already
+// mounted for client log uploads; SERVER_LOG_DIR overrides it and
+// SERVER_LOG_RETAIN_DAYS (default 30) sets how long files are kept.
+// Returns nil when file logging is disabled or unavailable - the caller
+// keeps running on stderr either way.
+func startFileLogging() *serverlog.Writer {
+	dir := os.Getenv("SERVER_LOG_DIR")
+	if dir == "" {
+		dir = filepath.Join(logfile.LogsDir, "server")
+	}
+	if strings.EqualFold(dir, "off") || strings.EqualFold(dir, "none") {
+		return nil
+	}
+
+	retain := 30
+	if v := os.Getenv("SERVER_LOG_RETAIN_DAYS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			retain = n
+		} else {
+			log.WithField("value", v).Warn("could not parse SERVER_LOG_RETAIN_DAYS; using 30")
+		}
+	}
+
+	w, err := serverlog.Open(dir, "cncstats", retain)
+	if err != nil {
+		log.WithError(err).WithField("dir", dir).
+			Warn("could not open the persistent log file; logging to stderr only")
+		return nil
+	}
+	log.SetOutput(io.MultiWriter(os.Stderr, w))
+	log.WithField("file", w.Path()).WithField("retain_days", retain).
+		Info("Persistent log file opened")
+	return w
+}
 
 func showHelp() {
 	fmt.Println("CNC Stats - Command and Conquer Replay Analyzer")
@@ -653,6 +699,12 @@ func uploadStatsHandler(c *gin.Context) {
 // is identified by X-Game-Seed and the player by X-Player. Each form file
 // is stored under <seed>/<player>/<original filename>. Call once per
 // player (each call may carry multiple files).
+//
+// X-Game-Seed is an opaque storage key, not necessarily a game seed: the
+// client also uploads here when an online host/join attempt fails before
+// any match exists, using a per-day bucket ("connfail-YYYYMMDD") with the
+// attempt timestamp in X-Player. pkg/logfile sanitizes both to a single
+// path segment.
 // @Summary Upload match log files for a player
 // @Description Store one or more client log files for a match, keyed by game seed and grouped by player. Send a multipart/form-data body with one or more file parts (any field names); files are expected to be gzip-compressed by the client. Call once per player. The total request body is capped at 64 MiB.
 // @Tags logs

--- a/pkg/coordinator/server.go
+++ b/pkg/coordinator/server.go
@@ -24,6 +24,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// logger tags every coordinator line with component=coordinator so a day's
+// matchmaking traffic can be pulled out of the shared application log with
+// one grep (the persistent copy lives under LOGS_DIR/server; see
+// pkg/serverlog).
+var logger = log.WithField("component", "coordinator")
+
 // TCPAddr and UDPAddr are the listen addresses, overridable via environment
 // variables (matching the STATS_DIR/MAPS_DIR convention elsewhere in this
 // repo). The game client defaults to TCP 27500 / UDP 27501.
@@ -60,6 +66,7 @@ type Session struct {
 	LocalAddr      string
 	HostingGame    string
 	JoiningGame    string // game id of the last join attempt (player-count bookkeeping)
+	Started        time.Time
 	LastSeen       time.Time
 	writeMu        sync.Mutex
 }
@@ -139,7 +146,7 @@ func (s *Server) Run(tcpAddr, udpAddr string) error {
 		return fmt.Errorf("listen tcp: %w", err)
 	}
 	defer tcpL.Close()
-	log.Printf("TCP signaling listening on %s", tcpL.Addr())
+	logger.Printf("TCP signaling listening on %s", tcpL.Addr())
 
 	udpResAddr, err := net.ResolveUDPAddr("udp", udpAddr)
 	if err != nil {
@@ -150,7 +157,7 @@ func (s *Server) Run(tcpAddr, udpAddr string) error {
 		return fmt.Errorf("listen udp: %w", err)
 	}
 	defer udpL.Close()
-	log.Printf("UDP STUN listening on %s", udpL.LocalAddr())
+	logger.Printf("UDP STUN listening on %s", udpL.LocalAddr())
 	s.UDPPort = udpL.LocalAddr().(*net.UDPAddr).Port
 
 	go s.handleUDP(udpL)
@@ -165,7 +172,7 @@ func (s *Server) acceptTCP(l net.Listener) error {
 			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
-			log.Printf("accept: %v", err)
+			logger.Printf("accept: %v", err)
 			continue
 		}
 		go s.handleTCPConn(conn)
@@ -227,6 +234,7 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 		Nick:       sanitizeNick(hello.Nick),
 		Version:    hello.Version,
 		RemoteAddr: conn.RemoteAddr().String(),
+		Started:    time.Now(),
 		LastSeen:   time.Now(),
 	}
 
@@ -242,13 +250,13 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 	}); err != nil {
 		return
 	}
-	log.Printf("session %s nick=%q version=%s from %s", token[:8], sess.Nick, sess.Version, sess.RemoteAddr)
+	logger.Printf("session %s nick=%q version=%s from %s", token[:8], sess.Nick, sess.Version, sess.RemoteAddr)
 
 	for {
 		line, err := r.ReadBytes('\n')
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("session %s read: %v", token[:8], err)
+				logger.Printf("session %s read: %v", token[:8], err)
 			}
 			return
 		}
@@ -257,6 +265,7 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 		s.mu.Unlock()
 		var env Envelope
 		if err := json.Unmarshal(line, &env); err != nil {
+			logger.Printf("session %s nick=%q rejected: bad envelope (%v)", token[:8], sess.Nick, err)
 			sess.send(MsgError, Error{Message: "bad envelope"})
 			continue
 		}
@@ -264,6 +273,12 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 			if err == io.EOF {
 				return
 			}
+			// Every rejection the client is shown is recorded here: this is
+			// the server's only record of why a player's host/join attempt
+			// failed, and the client-side ReleaseLog it uploads on failure
+			// is matched against it by nick + time.
+			logger.Printf("session %s nick=%q version=%s from %s: %s REJECTED: %v",
+				token[:8], sess.Nick, sess.Version, sess.RemoteAddr, env.Type, err)
 			sess.send(MsgError, Error{Message: err.Error()})
 		}
 	}
@@ -276,7 +291,7 @@ func (s *Server) handleRelayAttach(conn net.Conn, r *bufio.Reader, ra *RelayAtta
 	slot, ok := s.relays[ra.Token]
 	if !ok {
 		s.mu.Unlock()
-		log.Printf("relay_attach: unknown token from %s", conn.RemoteAddr())
+		logger.Printf("relay_attach: unknown token from %s", conn.RemoteAddr())
 		return false
 	}
 	switch ra.Role {
@@ -302,7 +317,7 @@ func (s *Server) handleRelayAttach(conn net.Conn, r *bufio.Reader, ra *RelayAtta
 	}
 	s.mu.Unlock()
 
-	log.Printf("relay_attach: token=%s role=%s from %s (paired=%v)",
+	logger.Printf("relay_attach: token=%s role=%s from %s (paired=%v)",
 		ra.Token[:8], ra.Role, conn.RemoteAddr(), ready)
 	if ready {
 		go spliceRelay(slot)
@@ -329,7 +344,7 @@ func spliceRelay(slot *relayState) {
 	slot.host.Close()
 	slot.viewer.Close()
 	<-done
-	log.Printf("relay closed (host=%s viewer=%s)", slot.host.RemoteAddr(), slot.viewer.RemoteAddr())
+	logger.Printf("relay closed (host=%s viewer=%s)", slot.host.RemoteAddr(), slot.viewer.RemoteAddr())
 }
 
 func (s *Server) handleMessage(sess *Session, env *Envelope) error {
@@ -344,7 +359,7 @@ func (s *Server) handleMessage(sess *Session, env *Envelope) error {
 			}
 		}
 		s.mu.Unlock()
-		log.Printf("game started: session=%s game=%s", sess.Token[:8], sess.HostingGame)
+		logger.Printf("game started: session=%s game=%s", sess.Token[:8], sess.HostingGame)
 		return nil
 	case MsgObserve:
 		var m Observe
@@ -384,7 +399,7 @@ func (s *Server) handleMessage(sess *Session, env *Envelope) error {
 			sess.JoiningGame = ""
 		}
 		s.mu.Unlock()
-		log.Printf("punch outcome session=%s nick=%q role=%s ok=%v lobby=%v game=%v ms=%d",
+		logger.Printf("punch outcome session=%s nick=%q role=%s ok=%v lobby=%v game=%v ms=%d",
 			sess.Token[:8], sess.Nick, m.Role, m.OK, m.LobbyOK, m.GameOK, m.MS)
 		return nil
 	case MsgHost:
@@ -446,7 +461,7 @@ func (s *Server) handleHost(sess *Session, m *Host) error {
 		created:  time.Now(),
 	}
 	s.mu.Unlock()
-	log.Printf("session %s hosting game %s name=%q", sess.Token[:8], gameID, m.Name)
+	logger.Printf("session %s hosting game %s name=%q", sess.Token[:8], gameID, m.Name)
 	return sess.send(MsgHosted, Hosted{GameID: gameID})
 }
 
@@ -509,7 +524,7 @@ func (s *Server) handleObserve(sess *Session, m *Observe) error {
 		s.mu.Unlock()
 		return fmt.Errorf("host unreachable: %w", err)
 	}
-	log.Printf("observe: viewer=%s game=%s token=%s", sess.Nick, m.GameID, token[:8])
+	logger.Printf("observe: viewer=%s game=%s token=%s", sess.Nick, m.GameID, token[:8])
 	return sess.send(MsgObserveOK, ObserveOK{Token: token})
 }
 
@@ -617,7 +632,7 @@ func (s *Server) handleJoin(sess *Session, m *Join) error {
 	if err := sess.send(MsgPeerInfo, hostInfo); err != nil {
 		return fmt.Errorf("guest send: %w", err)
 	}
-	log.Printf("matched host=%s(lobby=%s game=%s) <-> guest=%s(lobby=%s game=%s) game=%s",
+	logger.Printf("matched host=%s(lobby=%s game=%s) <-> guest=%s(lobby=%s game=%s) game=%s",
 		hostInfo.Nick, hostInfo.PublicAddr, hostInfo.GamePublicAddr,
 		guestInfo.Nick, guestInfo.PublicAddr, guestInfo.GamePublicAddr, m.GameID)
 	// Mesh notifications go out AFTER the host/guest pair so the new guest
@@ -626,12 +641,12 @@ func (s *Server) handleJoin(sess *Session, m *Join) error {
 	// is likely dying and will be reaped from the roster on disconnect.
 	for i, other := range meshPeers {
 		if err := other.send(MsgPeerInfo, newGuestInfo); err != nil {
-			log.Printf("mesh send to %s failed: %v", other.Nick, err)
+			logger.Printf("mesh send to %s failed: %v", other.Nick, err)
 		}
 		if err := sess.send(MsgPeerInfo, meshInfos[i]); err != nil {
-			log.Printf("mesh send to %s failed: %v", sess.Nick, err)
+			logger.Printf("mesh send to %s failed: %v", sess.Nick, err)
 		}
-		log.Printf("mesh peers %s(lobby=%s game=%s) <-> %s(lobby=%s game=%s) game=%s",
+		logger.Printf("mesh peers %s(lobby=%s game=%s) <-> %s(lobby=%s game=%s) game=%s",
 			other.Nick, meshInfos[i].PublicAddr, meshInfos[i].GamePublicAddr,
 			sess.Nick, newGuestInfo.PublicAddr, newGuestInfo.GamePublicAddr, m.GameID)
 	}
@@ -655,6 +670,13 @@ func (s *Server) removeGuestFromOtherGamesLocked(sess *Session, keepGameID strin
 }
 
 func (s *Server) dropSession(sess *Session) {
+	// Log the shape of the session on the way out: a client that connected,
+	// never got as far as hosting or joining, and vanished seconds later is
+	// the fingerprint of a punch/STUN failure on its side.
+	logger.Printf("session %s ended nick=%q from %s hosting=%q joining=%q after %s",
+		sess.Token[:8], sess.Nick, sess.RemoteAddr, sess.HostingGame, sess.JoiningGame,
+		time.Since(sess.Started).Round(time.Second))
+
 	s.mu.Lock()
 	delete(s.sessions, sess.Token)
 	if sess.HostingGame != "" {
@@ -672,7 +694,7 @@ func (s *Server) handleUDP(udpL *net.UDPConn) {
 			if errors.Is(err, net.ErrClosed) {
 				return
 			}
-			log.Printf("udp read: %v", err)
+			logger.Printf("udp read: %v", err)
 			continue
 		}
 		// Accept the legacy 20-byte probe (assume lobby) and the current
@@ -706,7 +728,7 @@ func (s *Server) handleUDP(udpL *net.UDPConn) {
 		}
 		s.mu.Unlock()
 		if !ok {
-			log.Printf("STUN probe with unknown token from %s", src)
+			logger.Printf("STUN probe with unknown token from %s", src)
 			continue
 		}
 
@@ -716,7 +738,7 @@ func (s *Server) handleUDP(udpL *net.UDPConn) {
 		binary.BigEndian.PutUint16(resp[8:10], uint16(src.Port))
 		udpL.WriteToUDP(resp, src)
 
-		log.Printf("session %s STUN purpose=%d public=%s", token[:8], purpose, public)
+		logger.Printf("session %s STUN purpose=%d public=%s", token[:8], purpose, public)
 	}
 }
 
@@ -728,7 +750,7 @@ func (s *Server) reapLoop() {
 		s.mu.Lock()
 		for tok, sess := range s.sessions {
 			if sess.LastSeen.Before(cutoff) {
-				log.Printf("reaping idle session %s", tok[:8])
+				logger.Printf("reaping idle session %s", tok[:8])
 				sess.Conn.Close()
 				delete(s.sessions, tok)
 				if sess.HostingGame != "" {
@@ -740,7 +762,7 @@ func (s *Server) reapLoop() {
 		relayCutoff := time.Now().Add(-RelayAttachTTL)
 		for tok, slot := range s.relays {
 			if slot.created.Before(relayCutoff) {
-				log.Printf("reaping unpaired relay %s", tok[:8])
+				logger.Printf("reaping unpaired relay %s", tok[:8])
 				if slot.host != nil {
 					slot.host.Close()
 				}

--- a/pkg/logfile/logfile.go
+++ b/pkg/logfile/logfile.go
@@ -41,9 +41,27 @@ type LogFile struct {
 	Size   int64  `json:"size"`
 }
 
-// MatchDir returns the per-seed storage directory for a match.
+// MatchDir returns the per-seed storage directory for a match. The seed is
+// reduced to a safe single path segment; use safeSeed when the caller needs
+// to know that the seed was unusable.
 func MatchDir(seed string) string {
-	return filepath.Join(LogsDir, seed)
+	safe, err := sanitizeComponent(seed)
+	if err != nil {
+		return filepath.Join(LogsDir, "invalid")
+	}
+	return filepath.Join(LogsDir, safe)
+}
+
+// safeSeed validates the seed as a storage key. Seeds are client-supplied
+// (an X-Game-Seed header) and are not always numeric: connection-failure
+// uploads, which have no match to key off, use a "connfail-YYYYMMDD" bucket.
+// Anything that isn't a single usable path segment is rejected rather than
+// silently rewritten, so a traversal attempt can never land outside LogsDir.
+func safeSeed(seed string) (string, error) {
+	if seed == "" {
+		return "", errors.New("logfile: empty seed")
+	}
+	return sanitizeComponent(seed)
 }
 
 // sanitizeComponent reduces an untrusted path component (player id or
@@ -65,8 +83,9 @@ func sanitizeComponent(raw string) (string, error) {
 // player and filename are sanitized to their basenames; a repeated
 // (seed, player, filename) overwrites silently.
 func Store(seed, player, filename string, data []byte) error {
-	if seed == "" {
-		return errors.New("logfile.Store: empty seed")
+	safeSeedName, err := safeSeed(seed)
+	if err != nil {
+		return err
 	}
 	safePlayer, err := sanitizeComponent(player)
 	if err != nil {
@@ -77,7 +96,7 @@ func Store(seed, player, filename string, data []byte) error {
 		return err
 	}
 
-	dir := filepath.Join(MatchDir(seed), safePlayer)
+	dir := filepath.Join(LogsDir, safeSeedName, safePlayer)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create log dir: %w", err)
 	}
@@ -89,20 +108,22 @@ func Store(seed, player, filename string, data []byte) error {
 
 // Exists reports whether any logs have been stored for the given seed.
 func Exists(seed string) bool {
-	if seed == "" {
+	safeSeedName, err := safeSeed(seed)
+	if err != nil {
 		return false
 	}
-	info, err := os.Stat(MatchDir(seed))
+	info, err := os.Stat(filepath.Join(LogsDir, safeSeedName))
 	return err == nil && info.IsDir()
 }
 
 // List returns every stored log file for a match, sorted by player then
 // filename. Returns an empty slice if the match has no logs.
 func List(seed string) ([]LogFile, error) {
-	if seed == "" {
-		return nil, errors.New("logfile.List: empty seed")
+	safeSeedName, err := safeSeed(seed)
+	if err != nil {
+		return nil, err
 	}
-	matchDir := MatchDir(seed)
+	matchDir := filepath.Join(LogsDir, safeSeedName)
 	players, err := os.ReadDir(matchDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -148,8 +169,9 @@ func List(seed string) ([]LogFile, error) {
 // Load returns the raw bytes of one stored log file. Returns
 // os.ErrNotExist if the file isn't stored.
 func Load(seed, player, filename string) ([]byte, error) {
-	if seed == "" {
-		return nil, errors.New("logfile.Load: empty seed")
+	safeSeedName, err := safeSeed(seed)
+	if err != nil {
+		return nil, err
 	}
 	safePlayer, err := sanitizeComponent(player)
 	if err != nil {
@@ -159,5 +181,5 @@ func Load(seed, player, filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return os.ReadFile(filepath.Join(MatchDir(seed), safePlayer, safeName))
+	return os.ReadFile(filepath.Join(LogsDir, safeSeedName, safePlayer, safeName))
 }

--- a/pkg/logfile/logfile_test.go
+++ b/pkg/logfile/logfile_test.go
@@ -1,0 +1,102 @@
+package logfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withTempLogsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := LogsDir
+	LogsDir = dir
+	t.Cleanup(func() { LogsDir = prev })
+	return dir
+}
+
+func TestStoreAndLoadNumericSeed(t *testing.T) {
+	dir := withTempLogsDir(t)
+	if err := Store("7774140", "131", "ReleaseLog.txt.gz", []byte("payload")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if !Exists("7774140") {
+		t.Error("Exists = false after Store")
+	}
+	got, err := Load("7774140", "131", "ReleaseLog.txt.gz")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("Load = %q", string(got))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "7774140", "131", "ReleaseLog.txt.gz")); err != nil {
+		t.Errorf("unexpected on-disk layout: %v", err)
+	}
+	files, err := List("7774140")
+	if err != nil || len(files) != 1 || files[0].Player != "131" {
+		t.Errorf("List = %+v, err %v", files, err)
+	}
+}
+
+// Connection-failure uploads have no match to key off, so they use a
+// non-numeric daily bucket. That has to round-trip like any other seed.
+func TestStoreConnectionFailureBucket(t *testing.T) {
+	withTempLogsDir(t)
+	const seed = "connfail-20260820"
+	if err := Store(seed, "CD-201455-host", "ReleaseLog.txt.gz", []byte("x")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := Store(seed, "CD-201502-join", "ReleaseLog.txt.gz", []byte("y")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	files, err := List(seed)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected both attempts under one bucket, got %+v", files)
+	}
+}
+
+func TestSeedCannotEscapeLogsDir(t *testing.T) {
+	dir := withTempLogsDir(t)
+	for _, seed := range []string{"../evil", "..\\evil", "a/../../evil", "/etc/evil"} {
+		if err := Store(seed, "p", "f.gz", []byte("x")); err != nil {
+			continue // rejected outright is fine too
+		}
+		// Stored: the file must still be inside LogsDir.
+		walked := false
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err == nil && !info.IsDir() {
+				walked = true
+				if !strings.HasPrefix(path, dir) {
+					t.Errorf("seed %q escaped LogsDir: %s", seed, path)
+				}
+			}
+			return nil
+		})
+		if !walked {
+			t.Errorf("seed %q stored nothing under LogsDir", seed)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dir), "evil")); !os.IsNotExist(err) {
+		t.Error("a sibling of LogsDir was created")
+	}
+}
+
+func TestEmptyAndUnusableSeedsRejected(t *testing.T) {
+	withTempLogsDir(t)
+	for _, seed := range []string{"", "..", ".", "   "} {
+		if err := Store(seed, "p", "f.gz", []byte("x")); err == nil {
+			t.Errorf("Store(%q) = nil, want error", seed)
+		}
+		if Exists(seed) {
+			t.Errorf("Exists(%q) = true", seed)
+		}
+		if _, err := List(seed); err == nil {
+			t.Errorf("List(%q) = nil error", seed)
+		}
+	}
+}

--- a/pkg/serverlog/serverlog.go
+++ b/pkg/serverlog/serverlog.go
@@ -1,0 +1,163 @@
+// Package serverlog persists the process's log stream to disk.
+//
+// The service normally logs to stderr, which docker captures per container.
+// That stream dies with the container: recreating it on a redeploy discards
+// every line the old one wrote, and those lines are the only record of what
+// the online coordinator told a player whose host/join attempt failed. This
+// package tees the same stream into a file under a mounted volume, one file
+// per UTC day, with a retention window so it can't grow without bound.
+//
+// Layout under Dir:
+//
+//	<prefix>-YYYY-MM-DD.log
+//
+// A Writer is safe for concurrent use: logrus writes from every request
+// goroutine and from the coordinator's session goroutines.
+package serverlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Writer is an io.Writer that appends to a per-day log file, rolling over
+// at UTC midnight and pruning files older than the retention window.
+type Writer struct {
+	mu         sync.Mutex
+	dir        string
+	prefix     string
+	retainDays int
+	day        string // "2006-01-02" of the currently open file
+	f          *os.File
+}
+
+// Open creates dir if needed and opens today's log file for appending.
+// retainDays <= 0 disables pruning.
+func Open(dir, prefix string, retainDays int) (*Writer, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("serverlog: empty dir")
+	}
+	if prefix == "" {
+		prefix = "server"
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("serverlog: create dir: %w", err)
+	}
+	w := &Writer{dir: dir, prefix: prefix, retainDays: retainDays}
+	if err := w.rollTo(time.Now().UTC().Format("2006-01-02")); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// Path returns the file currently being written.
+func (w *Writer) Path() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return ""
+	}
+	return w.f.Name()
+}
+
+// Write appends p to today's file, rolling over first if the UTC day
+// changed since the last write. A write that fails to roll over falls back
+// to the already-open file rather than dropping the line.
+func (w *Writer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if today := time.Now().UTC().Format("2006-01-02"); today != w.day {
+		// Roll failures are non-fatal: keep writing to the open file so a
+		// full disk or a permissions change can't silence the log.
+		_ = w.rollTo(today)
+	}
+	if w.f == nil {
+		return len(p), nil
+	}
+	return w.f.Write(p)
+}
+
+// Close closes the current file.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}
+
+// rollTo opens the file for the given day. Caller holds w.mu.
+func (w *Writer) rollTo(day string) error {
+	name := filepath.Join(w.dir, fmt.Sprintf("%s-%s.log", w.prefix, day))
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("serverlog: open %s: %w", name, err)
+	}
+	if w.f != nil {
+		w.f.Close()
+	}
+	w.f = f
+	w.day = day
+	w.prune()
+	return nil
+}
+
+// prune removes log files older than the retention window. Files are
+// selected by the date in their name, so a stopped service that never
+// wrote for a week still cleans up correctly on its next start. Caller
+// holds w.mu.
+func (w *Writer) prune() {
+	if w.retainDays <= 0 {
+		return
+	}
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -w.retainDays)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, w.prefix+"-") || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		datePart := strings.TrimSuffix(strings.TrimPrefix(name, w.prefix+"-"), ".log")
+		day, err := time.Parse("2006-01-02", datePart)
+		if err != nil {
+			continue
+		}
+		if day.Before(cutoff) {
+			os.Remove(filepath.Join(w.dir, name))
+		}
+	}
+}
+
+// Files lists the stored log files, newest first. Useful for tooling that
+// wants to fetch yesterday's log without knowing the naming scheme.
+func Files(dir, prefix string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := []string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), prefix+"-") && strings.HasSuffix(e.Name(), ".log") {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(out)))
+	return out, nil
+}

--- a/pkg/serverlog/serverlog_test.go
+++ b/pkg/serverlog/serverlog_test.go
@@ -1,0 +1,127 @@
+package serverlog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteAppendsToTodaysFile(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Open(dir, "cncstats", 30)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer w.Close()
+
+	if _, err := w.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := w.Write([]byte("world\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	want := filepath.Join(dir, "cncstats-"+time.Now().UTC().Format("2006-01-02")+".log")
+	if w.Path() != want {
+		t.Fatalf("Path() = %q, want %q", w.Path(), want)
+	}
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "hello\nworld\n" {
+		t.Fatalf("file contents = %q", string(data))
+	}
+}
+
+func TestReopenAppendsRatherThanTruncates(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Open(dir, "cncstats", 30)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	w.Write([]byte("first\n"))
+	w.Close()
+
+	w2, err := Open(dir, "cncstats", 30)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer w2.Close()
+	w2.Write([]byte("second\n"))
+
+	data, err := os.ReadFile(w2.Path())
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "first\nsecond\n" {
+		t.Fatalf("restart truncated the log: %q", string(data))
+	}
+}
+
+func TestWriteRollsOverOnDayChange(t *testing.T) {
+	dir := t.TempDir()
+	w, err := Open(dir, "cncstats", 30)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer w.Close()
+	w.Write([]byte("yesterday\n"))
+
+	// Pretend the open file belongs to an earlier day; the next write must
+	// roll over to today's file instead of appending to it.
+	stale := w.Path()
+	w.mu.Lock()
+	w.day = "2000-01-01"
+	w.mu.Unlock()
+
+	w.Write([]byte("today\n"))
+	if w.Path() != stale {
+		t.Fatalf("expected roll back to today's file %q, got %q", stale, w.Path())
+	}
+}
+
+func TestPruneRemovesOldFilesOnly(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "cncstats-2000-01-02.log")
+	keep := filepath.Join(dir, "cncstats-"+time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")+".log")
+	other := filepath.Join(dir, "unrelated.txt")
+	for _, p := range []string{old, keep, other} {
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	w, err := Open(dir, "cncstats", 7) // Open prunes
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer w.Close()
+
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be pruned", old)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("expected %s to be kept: %v", keep, err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("expected %s (not ours) to be untouched: %v", other, err)
+	}
+}
+
+func TestRetentionDisabled(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "cncstats-2000-01-02.log")
+	if err := os.WriteFile(old, []byte("x"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	w, err := Open(dir, "cncstats", 0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer w.Close()
+	if _, err := os.Stat(old); err != nil {
+		t.Errorf("retainDays<=0 must disable pruning: %v", err)
+	}
+}


### PR DESCRIPTION
The server half of GeneralsZulu/LegacyGameClient#104, which makes a player's
failed host/join diagnosable. This side keeps the server's own account of that
failure.

### The log survives a redeploy

The coordinator is the only witness to a failed host or join, and its record
lives in container stderr — discarded when the container is recreated. Going
looking for a player's failed session last week, `/var/lib/docker/containers/`
held exactly one container, the one created by that day's deploy, and every
line from the night in question was gone.

`pkg/serverlog` tees the logrus stream into `LOGS_DIR/server/cncstats-<date>.log`
alongside stderr. The logs volume is already mounted for client log uploads,
so the file outlives the container.

- one file per UTC day, rolled on the first write after midnight
- pruned by the date in the filename, so a service idle for a week still
  cleans up on its next start
- `SERVER_LOG_DIR` relocates it (or `off` disables it),
  `SERVER_LOG_RETAIN_DAYS` sets the window (default 30)
- best-effort: if the file can't be opened we log why and keep running on
  stderr

### The coordinator records what it was already telling players

Coordinator lines gain `component=coordinator`, so a night of matchmaking is
one grep out of the shared log. Two things it never recorded now are:

- **Every rejection sent to a client**, with the nick, version and address it
  went to. The player saw the reason and the server kept no copy, which is the
  wrong way round — they forget it and we can't ask them later.
- **How each session ended**: duration, and whether it ever reached hosting or
  joining. Connect → never host or join → gone in seconds is the fingerprint
  of a STUN or punch failure on the client side.

### Seed sanitizing

`pkg/logfile` now sanitizes the seed as well as the player and filename. The
seed is a client-supplied header and is no longer always numeric — the game
client uploads connection-failure logs under a `connfail-YYYYMMDD` bucket when
there is no match to key off. `Store`/`List`/`Load`/`Exists` reject a seed that
doesn't reduce to a single usable path segment instead of joining it into a
path.

### Verified

Run locally with the game client pointed at it:

- `LOGS_DIR/server/cncstats-2026-08-20.log` gets the full stream, coordinator
  lines tagged, and survives a restart by appending
- a probe sending `join` for an unknown game produces
  `session … nick="probe" version=… : join REJECTED: game doesnotexist not found`
  plus the session-ended line
- a real client's failure upload stores under `connfail-20260820/<nick>-<time>-<phase>/`
- new tests cover rollover, retention, restart-append, and seed traversal;
  `go test ./...` passes
