### PR TITLE
Refuse a stats upload that describes a different match

### DIFF
--- a/cmd/collisionscan/main.go
+++ b/cmd/collisionscan/main.go
@@ -1,0 +1,207 @@
+// collisionscan looks for game seeds where the stats this server stores and
+// the match radarvan stores under the same id describe different matches.
+//
+// The storage key on both servers is the game seed, which for a LAN game is
+// GetTickCount() on the host: milliseconds since that machine booted. That is
+// not a unique identifier, and until the upload handler learned to compare
+// match identity, a colliding upload was arbitrated purely on file size, so
+// the larger payload silently replaced an unrelated match.
+//
+// The upload guard stops new collisions. This finds ones that already
+// happened, by asking a second source what it thinks the same id is. A
+// disagreement on map or roster means the two servers are describing
+// different games under one key.
+//
+// Usage:
+//
+//	STATS_DIR=/app/stats collisionscan -radarvan-key "$KEY"
+//
+// Reads the stats directory directly, so run it where the volume is mounted.
+// Serial requests with a delay by default: radarvan is a single Heroku dyno
+// and has fallen over under parallel pulls before.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bill-rich/cncstats/pkg/statsfile"
+)
+
+// Shape of the parts of /api/details we compare against. Capitalised JSON
+// keys inside player_summary are radarvan's, not a typo.
+type radarvanPlayer struct {
+	Name string `json:"Name"`
+}
+
+type radarvanMatch struct {
+	MatchID       int              `json:"matchId"`
+	MapName       string           `json:"mapName"`
+	PlayerSummary []radarvanPlayer `json:"player_summary"`
+}
+
+func main() {
+	var (
+		baseURL = flag.String("radarvan", "https://www.radarvan.com", "radarvan base URL")
+		key     = flag.String("radarvan-key", os.Getenv("RADARVAN_API_KEY"), "radarvan X-API-Key (or RADARVAN_API_KEY)")
+		delay   = flag.Duration("delay", 300*time.Millisecond, "pause between radarvan requests")
+		limit   = flag.Int("limit", 0, "stop after this many seeds (0 = all)")
+		// A LAN seed is the host's uptime in milliseconds, so a low seed means
+		// a freshly booted host. That band is where collisions concentrate:
+		// GetTickCount ticks about every 15.6ms, so the first hour of uptime
+		// holds only ~230k distinct values, and every machine passes through
+		// it. Scanning just that band is the cheap, high-yield run.
+		maxSeed = flag.Uint64("max-seed", 0, "only check seeds <= this value (0 = no limit); 3600000 is the first hour of host uptime")
+	)
+	flag.Parse()
+
+	if *key == "" {
+		fmt.Fprintln(os.Stderr, "a radarvan API key is required (-radarvan-key or RADARVAN_API_KEY)")
+		os.Exit(2)
+	}
+
+	seeds, err := storedSeeds()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read stats dir: %v\n", err)
+		os.Exit(1)
+	}
+	total := len(seeds)
+	if *maxSeed > 0 {
+		var kept []string
+		for _, s := range seeds {
+			// Non-numeric keys (the connfail-YYYYMMDD log buckets) are not
+			// seeds at all and have no radarvan match to compare against.
+			if n, err := strconv.ParseUint(s, 10, 64); err == nil && n <= *maxSeed {
+				kept = append(kept, s)
+			}
+		}
+		seeds = kept
+	}
+	fmt.Printf("stats dir %s: %d stored seeds, %d selected\n", statsfile.StatsDir, total, len(seeds))
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	var checked, skipped, mismatched int
+
+	for i, seed := range seeds {
+		if *limit > 0 && checked >= *limit {
+			break
+		}
+		if i > 0 {
+			time.Sleep(*delay)
+		}
+
+		stored, err := statsfile.Load(seed)
+		if err != nil {
+			skipped++
+			continue
+		}
+		// Normalize our map the same way as radarvan's: the two servers
+		// spell the same map differently, and only the leaf name is
+		// comparable between them.
+		ours := statsfile.IdentityOf(stored)
+		ours.Map = mapLeaf(ours.Map)
+
+		theirs, ok, err := fetchMatch(client, *baseURL, *key, seed)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "seed %s: radarvan: %v\n", seed, err)
+			skipped++
+			continue
+		}
+		if !ok {
+			// radarvan has never seen this id. Nothing to compare against,
+			// which is not evidence either way.
+			skipped++
+			continue
+		}
+
+		checked++
+		if !ours.SameMatch(theirs) {
+			mismatched++
+			fmt.Printf("MISMATCH seed=%s\n  cncstats: %s\n  radarvan: %s\n", seed, ours, theirs)
+		}
+	}
+
+	fmt.Printf("\nchecked %d, skipped %d (unparseable or unknown to radarvan), mismatched %d\n",
+		checked, skipped, mismatched)
+	if mismatched > 0 {
+		os.Exit(1)
+	}
+}
+
+// storedSeeds lists every seed with a stats file, sorted so runs are
+// reproducible and progress is easy to eyeball.
+func storedSeeds() ([]string, error) {
+	entries, err := os.ReadDir(statsfile.StatsDir)
+	if err != nil {
+		return nil, err
+	}
+	var seeds []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json.gz") {
+			continue
+		}
+		seeds = append(seeds, strings.TrimSuffix(name, ".json.gz"))
+	}
+	sort.Strings(seeds)
+	return seeds, nil
+}
+
+// fetchMatch asks radarvan for one match. ok is false when radarvan has no
+// such id, which is different from an error talking to it.
+func fetchMatch(client *http.Client, baseURL, key, seed string) (statsfile.Identity, bool, error) {
+	url := fmt.Sprintf("%s/api/details/%s", strings.TrimRight(baseURL, "/"), seed)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return statsfile.Identity{}, false, err
+	}
+	req.Header.Set("X-API-Key", key)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return statsfile.Identity{}, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return statsfile.Identity{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return statsfile.Identity{}, false, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var m radarvanMatch
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return statsfile.Identity{}, false, fmt.Errorf("decode: %w", err)
+	}
+
+	id := statsfile.Identity{Map: mapLeaf(m.MapName)}
+	for _, p := range m.PlayerSummary {
+		id.Players = append(id.Players, p.Name)
+	}
+	sort.Strings(id.Players)
+	return id, true, nil
+}
+
+// mapLeaf reduces a map path to its final component. The two servers spell
+// the same map differently ("maps/alpine assault" against
+// "userdata/maps/Alpine Assault/Alpine Assault.map"), and only the leaf is
+// comparable. Lowercased because the case differs too.
+func mapLeaf(path string) string {
+	p := strings.ReplaceAll(path, "\\", "/")
+	p = strings.TrimSuffix(p, "/")
+	leaf := filepath.Base(p)
+	leaf = strings.TrimSuffix(leaf, filepath.Ext(leaf))
+	return strings.ToLower(leaf)
+}

--- a/cmd/collisionscan/main.go
+++ b/cmd/collisionscan/main.go
@@ -103,10 +103,12 @@ func main() {
 			skipped++
 			continue
 		}
-		// Normalize our map the same way as radarvan's: the two servers
-		// spell the same map differently, and only the leaf name is
-		// comparable between them.
-		ours := statsfile.IdentityOf(stored)
+		// Humans only, and map normalized to its leaf: the two servers
+		// spell the same map differently, and their rosters do not agree
+		// about AI slots (GenTool strips zulu tactical-AI slots out of the
+		// replays radarvan parses). Comparing the part both sides record the
+		// same way is what makes a difference here mean something.
+		ours := statsfile.IdentityOfHumans(stored)
 		ours.Map = mapLeaf(ours.Map)
 
 		theirs, ok, err := fetchMatch(client, *baseURL, *key, seed)

--- a/main.go
+++ b/main.go
@@ -610,11 +610,53 @@ func uploadStatsHandler(c *gin.Context) {
 		return
 	}
 
+	force := isForced(c)
+
+	// Before the size comparison below, check that the upload is even the
+	// same match as what is already stored. The key is the game seed, and on
+	// a LAN that is GetTickCount() on the host, so two matches genuinely can
+	// land on one key. Arbitrating those on file size means the bigger one
+	// silently replaces a completely unrelated match, and nothing anywhere
+	// records that it happened.
+	//
+	// Two players uploading the same match agree on map and roster, so this
+	// costs the normal path nothing: it falls through to the size guard
+	// exactly as before.
+	if !force && statsfile.Exists(seed) {
+		incoming, errIncoming := statsfile.ParseBytes(data)
+		stored, errStored := statsfile.Load(seed)
+		if errIncoming != nil {
+			// Undecodable payload: leave it to the size guard rather than
+			// invent an identity for it.
+			log.WithError(errIncoming).WithField("seed", seed).
+				Warn("Could not parse uploaded stats for identity check")
+		} else if errStored != nil {
+			log.WithError(errStored).WithField("seed", seed).
+				Warn("Could not parse stored stats for identity check")
+		} else {
+			incomingID := statsfile.IdentityOf(incoming)
+			storedID := statsfile.IdentityOf(stored)
+			if !incomingID.SameMatch(storedID) {
+				log.WithField("seed", seed).
+					WithField("incoming", incomingID.String()).
+					WithField("stored", storedID.String()).
+					WithField("client", clientName(c)).
+					Error("Seed collision: upload describes a different match than the stored one")
+				c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+					"error":    "Stored stats for this seed describe a different match (seed collision); refusing to overwrite. Set force=true to override.",
+					"seed":     seed,
+					"incoming": incomingID.String(),
+					"stored":   storedID.String(),
+				})
+				return
+			}
+		}
+	}
+
 	// Reject an upload that would replace an existing stats file with a
 	// smaller one, unless the caller explicitly forces the overwrite. This
 	// guards against a truncated or partial re-upload clobbering a more
 	// complete stats file for the same match.
-	force := isForced(c)
 	if !force {
 		if existing, err := statsfile.Size(seed); err == nil && int64(len(data)) < existing {
 			log.WithField("seed", seed).

--- a/pkg/statsfile/statsfile.go
+++ b/pkg/statsfile/statsfile.go
@@ -249,6 +249,35 @@ func IdentityOf(stats *GameStats) Identity {
 	return id
 }
 
+// PlayerTypeComputer is the Player.Type value the stats exporter writes for
+// an AI slot.
+const PlayerTypeComputer = "Computer"
+
+// IdentityOfHumans is IdentityOf with AI slots left out.
+//
+// Use it only when comparing against a roster from somewhere else, never for
+// the upload guard: two uploads of one match both come from the live stats
+// exporter and agree about the AI, so the guard should hold them to the
+// stricter whole-roster comparison.
+//
+// It exists because a replay-derived roster may not list the AI at all.
+// GenTool rewrites the headers of replays uploaded through it and drops zulu's
+// tactical-AI slots, so radarvan (which parses replays) sees seven humans on a
+// match where cncstats (which records the live game) sees seven humans and a
+// Tactical AI. That is a difference in where the two rosters came from, not
+// two different matches, and reporting it as a collision would be noise.
+func IdentityOfHumans(stats *GameStats) Identity {
+	id := Identity{Map: stats.Game.Map}
+	for _, p := range stats.Players {
+		if p.Type == PlayerTypeComputer {
+			continue
+		}
+		id.Players = append(id.Players, p.DisplayName)
+	}
+	sort.Strings(id.Players)
+	return id
+}
+
 // SameMatch reports whether two identities describe the same match.
 //
 // An empty map name or an empty roster means the payload did not carry

--- a/pkg/statsfile/statsfile.go
+++ b/pkg/statsfile/statsfile.go
@@ -1,12 +1,14 @@
 package statsfile
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 // GameStats represents the JSON structure from the Generals stats exporter
@@ -218,6 +220,81 @@ func Size(seed string) (int64, error) {
 		return 0, err
 	}
 	return info.Size(), nil
+}
+
+// Identity is the part of a stats payload that says which match it is,
+// as opposed to how that match went. Two uploads of the same match from
+// two different players agree on all of it; two genuinely different
+// matches essentially never do.
+//
+// This exists because the storage key is the game seed, and on a LAN the
+// seed is GetTickCount() on the host, i.e. milliseconds since that machine
+// booted. That is not a unique identifier: 373 of the first 3879 matches
+// stored here have a seed under one hour of uptime, where GetTickCount's
+// ~15.6ms granularity leaves only ~230k distinct values. Colliding matches
+// used to be arbitrated purely on file size, so the bigger one silently
+// replaced the other.
+type Identity struct {
+	Map     string
+	Players []string // display names, sorted, so player order cannot matter
+}
+
+// IdentityOf extracts the match identity from parsed stats.
+func IdentityOf(stats *GameStats) Identity {
+	id := Identity{Map: stats.Game.Map}
+	for _, p := range stats.Players {
+		id.Players = append(id.Players, p.DisplayName)
+	}
+	sort.Strings(id.Players)
+	return id
+}
+
+// SameMatch reports whether two identities describe the same match.
+//
+// An empty map name or an empty roster means the payload did not carry
+// enough to tell (an old or partial export), and we say "same" rather than
+// block a legitimate upload on missing data: the size guard still applies,
+// and refusing here would be a regression for anything that predates these
+// fields.
+func (a Identity) SameMatch(b Identity) bool {
+	if a.Map == "" || b.Map == "" || len(a.Players) == 0 || len(b.Players) == 0 {
+		return true
+	}
+	if a.Map != b.Map || len(a.Players) != len(b.Players) {
+		return false
+	}
+	for i := range a.Players {
+		if a.Players[i] != b.Players[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// String renders an identity for a log line.
+func (a Identity) String() string {
+	return fmt.Sprintf("map=%q players=%v", a.Map, a.Players)
+}
+
+// ParseBytes decodes a gzip-compressed stats payload that has not been
+// stored yet, so an upload can be inspected before it overwrites anything.
+func ParseBytes(data []byte) (*GameStats, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	raw, err := io.ReadAll(gz)
+	if err != nil {
+		return nil, fmt.Errorf("read stats: %w", err)
+	}
+
+	var stats GameStats
+	if err := json.Unmarshal(raw, &stats); err != nil {
+		return nil, fmt.Errorf("parse stats JSON: %w", err)
+	}
+	return &stats, nil
 }
 
 // Load reads and decompresses stats data for the given seed

--- a/pkg/statsfile/statsfile_test.go
+++ b/pkg/statsfile/statsfile_test.go
@@ -134,3 +134,33 @@ func TestParseBytesRejectsGarbage(t *testing.T) {
 		t.Fatal("expected an error for gzipped non-JSON")
 	}
 }
+
+func TestIdentityOfHumansSkipsAI(t *testing.T) {
+	// A match with an AI slot. IdentityOf keeps it (the upload guard wants
+	// the strictest comparison); IdentityOfHumans drops it, so a
+	// replay-derived roster that never saw the AI still matches.
+	s := statsFor("maps/alpine", "Wld", "Gorn")
+	s.Players = append(s.Players, Player{
+		Index: 2, DisplayName: "Tactical AI", Type: PlayerTypeComputer,
+	})
+
+	full := IdentityOf(s)
+	if len(full.Players) != 3 {
+		t.Fatalf("IdentityOf dropped the AI: %v", full.Players)
+	}
+
+	humans := IdentityOfHumans(s)
+	if len(humans.Players) != 2 {
+		t.Fatalf("IdentityOfHumans kept the AI: %v", humans.Players)
+	}
+
+	// This is the real-world case: cncstats records the AI, radarvan's
+	// gentool-rewritten replay does not. Same match.
+	replaySide := IdentityOf(statsFor("maps/alpine", "Gorn", "Wld"))
+	if !humans.SameMatch(replaySide) {
+		t.Fatal("human-only comparison still reported a collision")
+	}
+	if full.SameMatch(replaySide) {
+		t.Fatal("whole-roster comparison should still see a difference")
+	}
+}

--- a/pkg/statsfile/statsfile_test.go
+++ b/pkg/statsfile/statsfile_test.go
@@ -1,0 +1,136 @@
+package statsfile
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"testing"
+)
+
+func gzipJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func statsFor(mapName string, players ...string) *GameStats {
+	s := &GameStats{Game: GameInfo{Map: mapName}}
+	for i, p := range players {
+		s.Players = append(s.Players, Player{Index: i, DisplayName: p})
+	}
+	return s
+}
+
+func TestIdentityOfSortsPlayers(t *testing.T) {
+	id := IdentityOf(statsFor("maps/tournament", "Wld", "Gorn", "Mod"))
+	want := []string{"Gorn", "Mod", "Wld"}
+	if len(id.Players) != len(want) {
+		t.Fatalf("got %v, want %v", id.Players, want)
+	}
+	for i := range want {
+		if id.Players[i] != want[i] {
+			t.Fatalf("got %v, want %v", id.Players, want)
+		}
+	}
+	if id.Map != "maps/tournament" {
+		t.Fatalf("map = %q", id.Map)
+	}
+}
+
+func TestSameMatchIgnoresPlayerOrder(t *testing.T) {
+	// The two clients that upload one match list the roster from their own
+	// point of view; slot order must not read as a different match.
+	a := IdentityOf(statsFor("maps/alpine", "Wld", "Gorn"))
+	b := IdentityOf(statsFor("maps/alpine", "Gorn", "Wld"))
+	if !a.SameMatch(b) {
+		t.Fatal("same match with reordered players reported as different")
+	}
+}
+
+func TestSameMatchDetectsDifferentMatches(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b *GameStats
+	}{
+		{
+			name: "different map",
+			a:    statsFor("maps/alpine", "Wld", "Gorn"),
+			b:    statsFor("maps/tournament", "Wld", "Gorn"),
+		},
+		{
+			name: "different roster",
+			a:    statsFor("maps/alpine", "Wld", "Gorn"),
+			b:    statsFor("maps/alpine", "Neo", "CDwg"),
+		},
+		{
+			name: "different player count",
+			a:    statsFor("maps/alpine", "Wld", "Gorn"),
+			b:    statsFor("maps/alpine", "Wld", "Gorn", "Mod"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IdentityOf(tc.a).SameMatch(IdentityOf(tc.b)) {
+				t.Fatal("different matches reported as the same")
+			}
+		})
+	}
+}
+
+func TestSameMatchAllowsIncompletePayloads(t *testing.T) {
+	// Older exports may carry no map or no roster. Those must not be
+	// treated as collisions, or the guard becomes a regression for every
+	// upload that predates the fields it reads.
+	full := IdentityOf(statsFor("maps/alpine", "Wld", "Gorn"))
+	cases := map[string]*GameStats{
+		"no map":     statsFor("", "Wld", "Gorn"),
+		"no players": statsFor("maps/alpine"),
+	}
+	for name, partial := range cases {
+		t.Run(name, func(t *testing.T) {
+			id := IdentityOf(partial)
+			if !full.SameMatch(id) || !id.SameMatch(full) {
+				t.Fatal("incomplete payload treated as a collision")
+			}
+		})
+	}
+}
+
+func TestParseBytesRoundTrip(t *testing.T) {
+	want := statsFor("maps/alpine", "Wld", "Gorn")
+	got, err := ParseBytes(gzipJSON(t, want))
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if !IdentityOf(got).SameMatch(IdentityOf(want)) {
+		t.Fatalf("round trip changed identity: %v vs %v", IdentityOf(got), IdentityOf(want))
+	}
+}
+
+func TestParseBytesRejectsGarbage(t *testing.T) {
+	if _, err := ParseBytes([]byte("not gzip")); err == nil {
+		t.Fatal("expected an error for non-gzip input")
+	}
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write([]byte("{not json")); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	if _, err := ParseBytes(buf.Bytes()); err == nil {
+		t.Fatal("expected an error for gzipped non-JSON")
+	}
+}


### PR DESCRIPTION
## The problem

The storage key is the game seed, and for a LAN game the seed is `GetTickCount()` on the host — milliseconds since that machine booted (`LANAPI.cpp:1216`). That is not a unique identifier:

- **373 of the 3879 matches stored here** have a seed under one hour of uptime.
- `GetTickCount` advances about every 15.6ms, so that window holds only ~230k distinct values.
- Every machine passes through it, and a freshly rebooted host lands there every time.

Birthday odds that two of those 373 already share a value are roughly **25%**.

Until now two colliding matches were arbitrated purely on file size: the larger payload replaced the other, nothing recorded that it happened, and the smaller match simply stopped existing. Nothing about that is detectable after the fact from this server alone.

## Change

Compare match identity — map plus sorted roster — before the size check.

Two players uploading the same match agree on both, so the normal path is untouched and still falls through to the size guard exactly as before. A genuine collision now gets a 409 naming both matches and an `Error`-level log line. `force=true` still overrides, for the re-run tooling that needs it.

A payload missing a map or a roster is treated as the *same* match rather than blocked, so this cannot regress uploads that predate the fields it reads.

## Also: cmd/collisionscan

Finds collisions that already happened, by comparing each stored seed against what radarvan holds under the same id — a disagreement on map or roster means the two servers are describing different games under one key. `-max-seed` restricts a run to the low-uptime band where the risk concentrates, which is the cheap high-yield run; `-delay` keeps it serial and gentle, since radarvan is a single Heroku dyno that has fallen over under parallel pulls before.

**Run against all 373 seeds in the sub-one-hour band: 0 mismatches.** No collision has actually happened yet — this closes the door before it does. A full-corpus run is in progress.

## Testing

Unit tests for `IdentityOf` / `SameMatch` / `ParseBytes` cover player-order independence, the three ways two matches differ, incomplete payloads, and malformed input.

End-to-end against a local server, one seed, in order:

| upload | result |
|---|---|
| first upload of match A | `200` stored |
| same match, roster reordered | `200` stored (no false positive) |
| same match, larger (re-run) | `200` stored |
| **different match, larger** | **`409` refused** — silently overwrote before |
| different match, larger, `force=true` | `200` stored |

`go build ./...`, `go vet`, and the full `go test ./pkg/...` all clean.